### PR TITLE
[CHORE] schema row model

### DIFF
--- a/otlp-metric-store-backend-go/clickhouse_client.go
+++ b/otlp-metric-store-backend-go/clickhouse_client.go
@@ -9,6 +9,45 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
+type MetadataKey [16]byte
+
+type ReplacementRank [16]byte
+
+type GaugeMetadataRow struct {
+	MetadataKey           MetadataKey
+	ReplacementRank       ReplacementRank
+	ResourceAttributes    map[string]string
+	ResourceSchemaUrl     string
+	ScopeName             string
+	ScopeVersion          string
+	ScopeAttributes       map[string]string
+	ScopeDroppedAttrCount uint32
+	ScopeSchemaUrl        string
+	ServiceName           string
+	MetricName            string
+	MetricDescription     string
+	MetricUnit            string
+	Attributes            map[string]string
+}
+
+type SumMetadataRow struct {
+	GaugeMetadataRow
+	AggregationTemporality int32
+	IsMonotonic            bool
+}
+
+type GaugeDataPointRow struct {
+	MetadataKey   MetadataKey
+	StartTimeUnix time.Time
+	TimeUnix      time.Time
+	Value         float64
+	Flags         uint32
+}
+
+type SumDataPointRow struct {
+	GaugeDataPointRow
+}
+
 // GaugeRow represents a single gauge data point for ClickHouse insertion.
 type GaugeRow struct {
 	ResourceAttributes    map[string]string
@@ -73,9 +112,11 @@ func NewClickHouseMetricsStore(ctx context.Context, addr string, database string
 	return &ClickHouseMetricsStore{conn: conn}, nil
 }
 
-// CreateTables executes DDL for all 5 metric tables.
+// CreateTables executes DDL for all metric tables.
 func (s *ClickHouseMetricsStore) CreateTables(ctx context.Context) error {
 	ddls := []string{
+		createGaugeMetadataTableSQL,
+		createSumMetadataTableSQL,
 		createGaugeTableSQL,
 		createSumTableSQL,
 		createHistogramTableSQL,

--- a/otlp-metric-store-backend-go/clickhouse_schema.go
+++ b/otlp-metric-store-backend-go/clickhouse_schema.go
@@ -1,7 +1,9 @@
 package main
 
-const createGaugeTableSQL = `
-CREATE TABLE IF NOT EXISTS otel_metrics_gauge (
+const createGaugeMetadataTableSQL = `
+CREATE TABLE IF NOT EXISTS otel_metrics_gauge_metadata (
+    MetadataKey UUID CODEC(ZSTD(1)),
+    ReplacementRank UInt128 CODEC(ZSTD(1)),
     ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
     ResourceSchemaUrl String CODEC(ZSTD(1)),
     ScopeName String CODEC(ZSTD(1)),
@@ -14,10 +16,6 @@ CREATE TABLE IF NOT EXISTS otel_metrics_gauge (
     MetricDescription String CODEC(ZSTD(1)),
     MetricUnit String CODEC(ZSTD(1)),
     Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-    StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-    TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-    Value Float64 CODEC(ZSTD(1)),
-    Flags UInt32 CODEC(ZSTD(1)),
 
     INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
@@ -25,14 +23,15 @@ CREATE TABLE IF NOT EXISTS otel_metrics_gauge (
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE MergeTree()
-PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+) ENGINE ReplacingMergeTree(ReplacementRank)
+ORDER BY (MetadataKey)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 `
 
-const createSumTableSQL = `
-CREATE TABLE IF NOT EXISTS otel_metrics_sum (
+const createSumMetadataTableSQL = `
+CREATE TABLE IF NOT EXISTS otel_metrics_sum_metadata (
+    MetadataKey UUID CODEC(ZSTD(1)),
+    ReplacementRank UInt128 CODEC(ZSTD(1)),
     ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
     ResourceSchemaUrl String CODEC(ZSTD(1)),
     ScopeName String CODEC(ZSTD(1)),
@@ -45,10 +44,6 @@ CREATE TABLE IF NOT EXISTS otel_metrics_sum (
     MetricDescription String CODEC(ZSTD(1)),
     MetricUnit String CODEC(ZSTD(1)),
     Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-    StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-    TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-    Value Float64 CODEC(ZSTD(1)),
-    Flags UInt32 CODEC(ZSTD(1)),
     AggregationTemporality Int32 CODEC(ZSTD(1)),
     IsMonotonic Bool CODEC(ZSTD(1)),
 
@@ -58,9 +53,34 @@ CREATE TABLE IF NOT EXISTS otel_metrics_sum (
     INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE ReplacingMergeTree(ReplacementRank)
+ORDER BY (MetadataKey)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+`
+
+const createGaugeTableSQL = `
+CREATE TABLE IF NOT EXISTS otel_metrics_gauge (
+    MetadataKey UUID CODEC(ZSTD(1)),
+    StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    Value Float64 CODEC(ZSTD(1)),
+    Flags UInt32 CODEC(ZSTD(1))
 ) ENGINE MergeTree()
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+ORDER BY (toUnixTimestamp64Nano(TimeUnix), MetadataKey)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+`
+
+const createSumTableSQL = `
+CREATE TABLE IF NOT EXISTS otel_metrics_sum (
+    MetadataKey UUID CODEC(ZSTD(1)),
+    StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    Value Float64 CODEC(ZSTD(1)),
+    Flags UInt32 CODEC(ZSTD(1))
+) ENGINE MergeTree()
+PARTITION BY toDate(TimeUnix)
+ORDER BY (toUnixTimestamp64Nano(TimeUnix), MetadataKey)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 `
 

--- a/otlp-metric-store-backend-go/openspec/changes/normalize-metric-metadata-storage/tasks.md
+++ b/otlp-metric-store-backend-go/openspec/changes/normalize-metric-metadata-storage/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Schema and row model
 
-- [ ] 1.1 Add separate ClickHouse gauge and sum metadata lookup table schemas using `ReplacingMergeTree`, each with a compact 128-bit metadata key column, a deterministic replacement-rank/version field for non-identifying metadata, and separate non-identifying fields for description and schema URLs.
-- [ ] 1.2 Replace denormalized gauge and sum table schemas with datapoint-focused schemas that store the 128-bit metadata reference to the corresponding metadata table plus measurement fields.
-- [ ] 1.3 Introduce Go row types for gauge metadata, sum metadata, and normalized gauge and sum datapoint records.
+- [x] 1.1 Add separate ClickHouse gauge and sum metadata lookup table schemas using `ReplacingMergeTree`, each with a compact 128-bit metadata key column, a deterministic replacement-rank/version field for non-identifying metadata, and separate non-identifying fields for description and schema URLs.
+- [x] 1.2 Replace denormalized gauge and sum table schemas with datapoint-focused schemas that store the 128-bit metadata reference to the corresponding metadata table plus measurement fields.
+- [x] 1.3 Introduce Go row types for gauge metadata, sum metadata, and normalized gauge and sum datapoint records.
 
 ## 2. Metadata identity and mapping
 


### PR DESCRIPTION
This pull request introduces a major refactor to the ClickHouse schema and Go data model for OTLP metric storage, normalizing the way metric metadata is stored and referenced. The changes separate metadata from datapoints for gauge and sum metrics, introduce new metadata tables using `ReplacingMergeTree`, and update the Go code to use new row types reflecting this normalized schema.

Schema normalization and table refactor:

* Added new ClickHouse tables `otel_metrics_gauge_metadata` and `otel_metrics_sum_metadata` for storing gauge and sum metric metadata, respectively, using `ReplacingMergeTree` with `MetadataKey` as the primary key and `ReplacementRank` for versioning. These tables now store all descriptive and schema-related metadata fields. [[1]](diffhunk://#diff-382f3ee3784ee69b4b0af0db58034f435694e412786e2987a7b3b5e5d0a16db8L3-R6) [[2]](diffhunk://#diff-382f3ee3784ee69b4b0af0db58034f435694e412786e2987a7b3b5e5d0a16db8L17-R34) [[3]](diffhunk://#diff-382f3ee3784ee69b4b0af0db58034f435694e412786e2987a7b3b5e5d0a16db8L48-L51) [[4]](diffhunk://#diff-382f3ee3784ee69b4b0af0db58034f435694e412786e2987a7b3b5e5d0a16db8R56-R83)
* Refactored the existing `otel_metrics_gauge` and `otel_metrics_sum` tables to store only datapoint-specific fields, referencing the associated metadata via a `MetadataKey` column. These tables now use a normalized schema focused on measurement data.

Go data model updates:

* Introduced new Go types: `GaugeMetadataRow`, `SumMetadataRow`, `GaugeDataPointRow`, and `SumDataPointRow` to match the new table layouts and enforce separation of metadata and datapoint records.

Table creation and migration:

* Updated the `CreateTables` method in the ClickHouse client to create the new metadata tables along with the datapoint tables.

Documentation and tracking:

* Updated the project task list to mark the normalization of metric metadata storage as complete, reflecting the implemented schema and Go model changes.