### PR TITLE
[CHORE] add metadata normalization validation coverage

### DIFF
--- a/otlp-metric-store-backend-go/go.mod
+++ b/otlp-metric-store-backend-go/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
+	github.com/google/uuid v1.6.0
 	github.com/testcontainers/testcontainers-go v0.40.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.16.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.66.0
@@ -45,7 +46,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/otlp-metric-store-backend-go/integration_test.go
+++ b/otlp-metric-store-backend-go/integration_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -95,6 +96,24 @@ func TestCreateTables(t *testing.T) {
 			t.Errorf("expected table %s to exist, got count=%d", table, count)
 		}
 	}
+
+	expectedMetadataEngines := map[string]string{
+		"otel_metrics_gauge_metadata": "ReplacingMergeTree",
+		"otel_metrics_sum_metadata":   "ReplacingMergeTree",
+	}
+
+	for table, expectedEngine := range expectedMetadataEngines {
+		var engine string
+		err := store.conn.QueryRow(ctx,
+			"SELECT engine FROM system.tables WHERE database = 'default' AND name = $1", table,
+		).Scan(&engine)
+		if err != nil {
+			t.Fatalf("querying engine for %s: %v", table, err)
+		}
+		if engine != expectedEngine {
+			t.Errorf("expected table %s to use %s, got %s", table, expectedEngine, engine)
+		}
+	}
 }
 
 func TestInsertGauge(t *testing.T) {
@@ -156,13 +175,15 @@ func TestInsertGauge(t *testing.T) {
 	}
 
 	var (
-		serviceName string
-		metricName  string
-		value       float64
+		serviceName          string
+		metricName           string
+		datapointMetadataKey MetadataKey
+		metadataKey          MetadataKey
+		value                float64
 	)
 	err := store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, g.Value FROM otel_metrics_gauge g INNER JOIN otel_metrics_gauge_metadata m USING (MetadataKey) WHERE m.MetricName = 'cpu.utilization'",
-	).Scan(&serviceName, &metricName, &value)
+		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge g INNER JOIN otel_metrics_gauge_metadata FINAL m USING (MetadataKey) WHERE m.MetricName = 'cpu.utilization'",
+	).Scan(&serviceName, &metricName, &datapointMetadataKey, &metadataKey, &value)
 	if err != nil {
 		t.Fatalf("querying gauge: %v", err)
 	}
@@ -172,6 +193,9 @@ func TestInsertGauge(t *testing.T) {
 	}
 	if metricName != "cpu.utilization" {
 		t.Errorf("expected MetricName=cpu.utilization, got %s", metricName)
+	}
+	if datapointMetadataKey != metadataKey {
+		t.Errorf("expected datapoint metadata key %s to reference metadata row %s", datapointMetadataKey, metadataKey)
 	}
 	if value != 42.5 {
 		t.Errorf("expected Value=42.5, got %f", value)
@@ -244,13 +268,15 @@ func TestInsertSum(t *testing.T) {
 	var (
 		serviceName            string
 		metricName             string
+		datapointMetadataKey   MetadataKey
+		metadataKey            MetadataKey
 		value                  float64
 		aggregationTemporality int32
 		isMonotonic            bool
 	)
 	err := store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, s.Value, m.AggregationTemporality, m.IsMonotonic FROM otel_metrics_sum s INNER JOIN otel_metrics_sum_metadata m USING (MetadataKey) WHERE m.MetricName = 'http.requests.total'",
-	).Scan(&serviceName, &metricName, &value, &aggregationTemporality, &isMonotonic)
+		"SELECT m.ServiceName, m.MetricName, s.MetadataKey, m.MetadataKey, s.Value, m.AggregationTemporality, m.IsMonotonic FROM otel_metrics_sum s INNER JOIN otel_metrics_sum_metadata FINAL m USING (MetadataKey) WHERE m.MetricName = 'http.requests.total'",
+	).Scan(&serviceName, &metricName, &datapointMetadataKey, &metadataKey, &value, &aggregationTemporality, &isMonotonic)
 	if err != nil {
 		t.Fatalf("querying sum: %v", err)
 	}
@@ -261,6 +287,9 @@ func TestInsertSum(t *testing.T) {
 	if metricName != "http.requests.total" {
 		t.Errorf("expected MetricName=http.requests.total, got %s", metricName)
 	}
+	if datapointMetadataKey != metadataKey {
+		t.Errorf("expected datapoint metadata key %s to reference metadata row %s", datapointMetadataKey, metadataKey)
+	}
 	if value != 1234 {
 		t.Errorf("expected Value=1234, got %f", value)
 	}
@@ -269,6 +298,276 @@ func TestInsertSum(t *testing.T) {
 	}
 	if !isMonotonic {
 		t.Errorf("expected IsMonotonic=true, got false")
+	}
+}
+
+func TestGaugeMetadataReplacingMergeTreeSemantics(t *testing.T) {
+	store, cleanup := setupClickHouse(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := store.CreateTables(ctx); err != nil {
+		t.Fatalf("creating tables: %v", err)
+	}
+
+	first := makeTestGaugeMetadataRow(
+		[]*commonpb.KeyValue{stringAttr("service.name", "test-service"), stringAttr("host.name", "test-host")},
+		nil,
+		[]*commonpb.KeyValue{stringAttr("cpu", "0")},
+		"https://resource.schema/1",
+		"https://scope.schema/1",
+		"CPU utilization percentage",
+		"%",
+	)
+	second := makeTestGaugeMetadataRow(
+		[]*commonpb.KeyValue{stringAttr("service.name", "test-service"), stringAttr("host.name", "test-host")},
+		nil,
+		[]*commonpb.KeyValue{stringAttr("cpu", "0")},
+		"https://resource.schema/2",
+		"https://scope.schema/2",
+		"CPU utilization percentage v2",
+		"%",
+	)
+
+	if first.MetadataKey != second.MetadataKey {
+		t.Fatalf("expected non-identifying metadata changes to reuse the same metadata key, got %s and %s", first.MetadataKey, second.MetadataKey)
+	}
+
+	if err := store.InsertGaugeMetadata(ctx, []MetricMetadataRow{first, second}); err != nil {
+		t.Fatalf("inserting gauge metadata rows: %v", err)
+	}
+
+	var physicalRows uint64
+	err := store.conn.QueryRow(ctx,
+		"SELECT count() FROM otel_metrics_gauge_metadata WHERE MetadataKey = $1",
+		first.MetadataKey,
+	).Scan(&physicalRows)
+	if err != nil {
+		t.Fatalf("counting physical metadata rows: %v", err)
+	}
+	if physicalRows != 2 {
+		t.Fatalf("expected 2 physical metadata rows before merge, got %d", physicalRows)
+	}
+
+	var logicalRows uint64
+	err = store.conn.QueryRow(ctx,
+		"SELECT count() FROM otel_metrics_gauge_metadata FINAL WHERE MetadataKey = $1",
+		first.MetadataKey,
+	).Scan(&logicalRows)
+	if err != nil {
+		t.Fatalf("counting logical metadata rows: %v", err)
+	}
+	if logicalRows != 1 {
+		t.Fatalf("expected FINAL to return 1 logical metadata row, got %d", logicalRows)
+	}
+
+	winner := first
+	if bytes.Compare(second.ReplacementRank[:], first.ReplacementRank[:]) > 0 {
+		winner = second
+	}
+
+	var (
+		metricDescription string
+		resourceSchemaURL string
+		scopeSchemaURL    string
+	)
+	err = store.conn.QueryRow(ctx,
+		"SELECT MetricDescription, ResourceSchemaUrl, ScopeSchemaUrl FROM otel_metrics_gauge_metadata FINAL WHERE MetadataKey = $1",
+		first.MetadataKey,
+	).Scan(&metricDescription, &resourceSchemaURL, &scopeSchemaURL)
+	if err != nil {
+		t.Fatalf("querying logical metadata survivor: %v", err)
+	}
+	if metricDescription != winner.MetricDescription {
+		t.Errorf("expected surviving description %q, got %q", winner.MetricDescription, metricDescription)
+	}
+	if resourceSchemaURL != winner.ResourceSchemaUrl {
+		t.Errorf("expected surviving resource schema URL %q, got %q", winner.ResourceSchemaUrl, resourceSchemaURL)
+	}
+	if scopeSchemaURL != winner.ScopeSchemaUrl {
+		t.Errorf("expected surviving scope schema URL %q, got %q", winner.ScopeSchemaUrl, scopeSchemaURL)
+	}
+}
+
+func TestGaugeMetadataIdentifyingDriftCreatesNewIdentity(t *testing.T) {
+	store, cleanup := setupClickHouse(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := store.CreateTables(ctx); err != nil {
+		t.Fatalf("creating tables: %v", err)
+	}
+
+	now := uint64(time.Now().UnixNano())
+	firstRows := MapNormalizedGaugeRows([]*metricspb.ResourceMetrics{newGaugeResourceMetrics(now, "test-service", "test-host-a", "cpu.utilization", "%", "CPU utilization percentage", 42.5)})
+	secondRows := MapNormalizedGaugeRows([]*metricspb.ResourceMetrics{newGaugeResourceMetrics(now+1, "test-service", "test-host-b", "cpu.utilization", "%", "CPU utilization percentage", 43.5)})
+
+	if err := store.InsertGaugeMetadata(ctx, append(firstRows.Metadata, secondRows.Metadata...)); err != nil {
+		t.Fatalf("inserting gauge metadata rows: %v", err)
+	}
+	if err := store.InsertGaugeDataPoints(ctx, append(firstRows.DataPoints, secondRows.DataPoints...)); err != nil {
+		t.Fatalf("inserting gauge datapoint rows: %v", err)
+	}
+
+	var distinctMetadataKeys uint64
+	err := store.conn.QueryRow(ctx,
+		"SELECT countDistinct(MetadataKey) FROM otel_metrics_gauge_metadata FINAL WHERE MetricName = 'cpu.utilization'",
+	).Scan(&distinctMetadataKeys)
+	if err != nil {
+		t.Fatalf("counting distinct metadata keys: %v", err)
+	}
+	if distinctMetadataKeys != 2 {
+		t.Fatalf("expected identifying drift to create 2 metadata identities, got %d", distinctMetadataKeys)
+	}
+
+	var datapointRows uint64
+	err = store.conn.QueryRow(ctx,
+		"SELECT count() FROM otel_metrics_gauge WHERE MetadataKey IN ($1, $2)",
+		firstRows.Metadata[0].MetadataKey,
+		secondRows.Metadata[0].MetadataKey,
+	).Scan(&datapointRows)
+	if err != nil {
+		t.Fatalf("counting datapoint rows: %v", err)
+	}
+	if datapointRows != 2 {
+		t.Fatalf("expected 2 datapoints referencing drifted metadata identities, got %d", datapointRows)
+	}
+}
+
+func TestSumMetadataReplacingMergeTreeSemantics(t *testing.T) {
+	store, cleanup := setupClickHouse(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := store.CreateTables(ctx); err != nil {
+		t.Fatalf("creating tables: %v", err)
+	}
+
+	first := makeTestSumMetadataRow(
+		[]*commonpb.KeyValue{stringAttr("service.name", "test-service"), stringAttr("host.name", "test-host")},
+		nil,
+		[]*commonpb.KeyValue{stringAttr("method", "GET")},
+		"https://resource.schema/1",
+		"https://scope.schema/1",
+		"Total HTTP requests",
+		"{request}",
+		metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+		true,
+	)
+	second := makeTestSumMetadataRow(
+		[]*commonpb.KeyValue{stringAttr("service.name", "test-service"), stringAttr("host.name", "test-host")},
+		nil,
+		[]*commonpb.KeyValue{stringAttr("method", "GET")},
+		"https://resource.schema/2",
+		"https://scope.schema/2",
+		"Total HTTP requests v2",
+		"{request}",
+		metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+		true,
+	)
+
+	if first.MetadataKey != second.MetadataKey {
+		t.Fatalf("expected non-identifying metadata changes to reuse the same metadata key, got %s and %s", first.MetadataKey, second.MetadataKey)
+	}
+
+	if err := store.InsertSumMetadata(ctx, []SumMetadataRow{first, second}); err != nil {
+		t.Fatalf("inserting sum metadata rows: %v", err)
+	}
+
+	var physicalRows uint64
+	err := store.conn.QueryRow(ctx,
+		"SELECT count() FROM otel_metrics_sum_metadata WHERE MetadataKey = $1",
+		first.MetadataKey,
+	).Scan(&physicalRows)
+	if err != nil {
+		t.Fatalf("counting physical metadata rows: %v", err)
+	}
+	if physicalRows != 2 {
+		t.Fatalf("expected 2 physical metadata rows before merge, got %d", physicalRows)
+	}
+
+	var logicalRows uint64
+	err = store.conn.QueryRow(ctx,
+		"SELECT count() FROM otel_metrics_sum_metadata FINAL WHERE MetadataKey = $1",
+		first.MetadataKey,
+	).Scan(&logicalRows)
+	if err != nil {
+		t.Fatalf("counting logical metadata rows: %v", err)
+	}
+	if logicalRows != 1 {
+		t.Fatalf("expected FINAL to return 1 logical metadata row, got %d", logicalRows)
+	}
+
+	winner := first
+	if bytes.Compare(second.ReplacementRank[:], first.ReplacementRank[:]) > 0 {
+		winner = second
+	}
+
+	var (
+		metricDescription string
+		resourceSchemaURL string
+		scopeSchemaURL    string
+	)
+	err = store.conn.QueryRow(ctx,
+		"SELECT MetricDescription, ResourceSchemaUrl, ScopeSchemaUrl FROM otel_metrics_sum_metadata FINAL WHERE MetadataKey = $1",
+		first.MetadataKey,
+	).Scan(&metricDescription, &resourceSchemaURL, &scopeSchemaURL)
+	if err != nil {
+		t.Fatalf("querying logical metadata survivor: %v", err)
+	}
+	if metricDescription != winner.MetricDescription {
+		t.Errorf("expected surviving description %q, got %q", winner.MetricDescription, metricDescription)
+	}
+	if resourceSchemaURL != winner.ResourceSchemaUrl {
+		t.Errorf("expected surviving resource schema URL %q, got %q", winner.ResourceSchemaUrl, resourceSchemaURL)
+	}
+	if scopeSchemaURL != winner.ScopeSchemaUrl {
+		t.Errorf("expected surviving scope schema URL %q, got %q", winner.ScopeSchemaUrl, scopeSchemaURL)
+	}
+}
+
+func TestSumMetadataIdentifyingDriftCreatesNewIdentity(t *testing.T) {
+	store, cleanup := setupClickHouse(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := store.CreateTables(ctx); err != nil {
+		t.Fatalf("creating tables: %v", err)
+	}
+
+	now := uint64(time.Now().UnixNano())
+	firstRows := MapNormalizedSumRows([]*metricspb.ResourceMetrics{newSumResourceMetrics(now, "test-service", "test-host", "http.requests.total", "{request}", "Total HTTP requests", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true, 1234)})
+	secondRows := MapNormalizedSumRows([]*metricspb.ResourceMetrics{newSumResourceMetrics(now+1, "test-service", "test-host", "http.requests.total", "{request}", "Total HTTP requests", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, true, 1235)})
+
+	if err := store.InsertSumMetadata(ctx, append(firstRows.Metadata, secondRows.Metadata...)); err != nil {
+		t.Fatalf("inserting sum metadata rows: %v", err)
+	}
+	if err := store.InsertSumDataPoints(ctx, append(firstRows.DataPoints, secondRows.DataPoints...)); err != nil {
+		t.Fatalf("inserting sum datapoint rows: %v", err)
+	}
+
+	var distinctMetadataKeys uint64
+	err := store.conn.QueryRow(ctx,
+		"SELECT countDistinct(MetadataKey) FROM otel_metrics_sum_metadata FINAL WHERE MetricName = 'http.requests.total'",
+	).Scan(&distinctMetadataKeys)
+	if err != nil {
+		t.Fatalf("counting distinct metadata keys: %v", err)
+	}
+	if distinctMetadataKeys != 2 {
+		t.Fatalf("expected identifying drift to create 2 metadata identities, got %d", distinctMetadataKeys)
+	}
+
+	var datapointRows uint64
+	err = store.conn.QueryRow(ctx,
+		"SELECT count() FROM otel_metrics_sum WHERE MetadataKey IN ($1, $2)",
+		firstRows.Metadata[0].MetadataKey,
+		secondRows.Metadata[0].MetadataKey,
+	).Scan(&datapointRows)
+	if err != nil {
+		t.Fatalf("counting datapoint rows: %v", err)
+	}
+	if datapointRows != 2 {
+		t.Fatalf("expected 2 datapoints referencing drifted metadata identities, got %d", datapointRows)
 	}
 }
 
@@ -344,20 +643,112 @@ func TestGRPCToClickHouse(t *testing.T) {
 
 	// Verify the metric landed in ClickHouse.
 	var (
-		svcName    string
-		metricName string
-		value      float64
+		svcName              string
+		metricName           string
+		datapointMetadataKey MetadataKey
+		metadataKey          MetadataKey
+		value                float64
 	)
 	err = store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, g.Value FROM otel_metrics_gauge g INNER JOIN otel_metrics_gauge_metadata m USING (MetadataKey) WHERE m.MetricName = 'e2e.gauge'",
-	).Scan(&svcName, &metricName, &value)
+		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge g INNER JOIN otel_metrics_gauge_metadata FINAL m USING (MetadataKey) WHERE m.MetricName = 'e2e.gauge'",
+	).Scan(&svcName, &metricName, &datapointMetadataKey, &metadataKey, &value)
 	if err != nil {
 		t.Fatalf("querying clickhouse: %v", err)
 	}
 	if svcName != "e2e-service" {
 		t.Errorf("expected ServiceName=e2e-service, got %s", svcName)
 	}
+	if metricName != "e2e.gauge" {
+		t.Errorf("expected MetricName=e2e.gauge, got %s", metricName)
+	}
+	if datapointMetadataKey != metadataKey {
+		t.Errorf("expected datapoint metadata key %s to reference metadata row %s", datapointMetadataKey, metadataKey)
+	}
 	if value != 99.9 {
 		t.Errorf("expected Value=99.9, got %f", value)
+	}
+}
+
+func newGaugeResourceMetrics(now uint64, service string, host string, metricName string, unit string, description string, value float64) *metricspb.ResourceMetrics {
+	return &metricspb.ResourceMetrics{
+		Resource: &resourcepb.Resource{
+			Attributes: []*commonpb.KeyValue{
+				stringAttr("service.name", service),
+				stringAttr("host.name", host),
+			},
+		},
+		SchemaUrl: "https://opentelemetry.io/schemas/1.4.0",
+		ScopeMetrics: []*metricspb.ScopeMetrics{
+			{
+				Scope: &commonpb.InstrumentationScope{
+					Name:    "test-scope",
+					Version: "1.0.0",
+				},
+				Metrics: []*metricspb.Metric{
+					{
+						Name:        metricName,
+						Description: description,
+						Unit:        unit,
+						Data: &metricspb.Metric_Gauge{
+							Gauge: &metricspb.Gauge{
+								DataPoints: []*metricspb.NumberDataPoint{
+									{
+										Attributes: []*commonpb.KeyValue{
+											stringAttr("cpu", "0"),
+										},
+										StartTimeUnixNano: now - uint64(time.Minute),
+										TimeUnixNano:      now,
+										Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: value},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newSumResourceMetrics(now uint64, service string, host string, metricName string, unit string, description string, temporality metricspb.AggregationTemporality, monotonic bool, value float64) *metricspb.ResourceMetrics {
+	return &metricspb.ResourceMetrics{
+		Resource: &resourcepb.Resource{
+			Attributes: []*commonpb.KeyValue{
+				stringAttr("service.name", service),
+				stringAttr("host.name", host),
+			},
+		},
+		SchemaUrl: "https://opentelemetry.io/schemas/1.4.0",
+		ScopeMetrics: []*metricspb.ScopeMetrics{
+			{
+				Scope: &commonpb.InstrumentationScope{
+					Name:    "test-scope",
+					Version: "1.0.0",
+				},
+				Metrics: []*metricspb.Metric{
+					{
+						Name:        metricName,
+						Description: description,
+						Unit:        unit,
+						Data: &metricspb.Metric_Sum{
+							Sum: &metricspb.Sum{
+								AggregationTemporality: temporality,
+								IsMonotonic:            monotonic,
+								DataPoints: []*metricspb.NumberDataPoint{
+									{
+										Attributes: []*commonpb.KeyValue{
+											stringAttr("method", "GET"),
+										},
+										StartTimeUnixNano: now - uint64(time.Minute),
+										TimeUnixNano:      now,
+										Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: value},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/otlp-metric-store-backend-go/metrics_identity_test.go
+++ b/otlp-metric-store-backend-go/metrics_identity_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"testing"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+)
+
+func TestMetadataIdentity(t *testing.T) {
+	t.Run("reordered attributes resolve to the same gauge metadata key", func(t *testing.T) {
+		first := makeTestGaugeMetadataRow(
+			[]*commonpb.KeyValue{
+				stringAttr("service.name", "svc"),
+				stringAttr("host.name", "host-a"),
+			},
+			[]*commonpb.KeyValue{
+				stringAttr("scope.attr.a", "a"),
+				stringAttr("scope.attr.b", "b"),
+			},
+			[]*commonpb.KeyValue{
+				stringAttr("cpu", "0"),
+				stringAttr("state", "idle"),
+			},
+			"https://resource.schema/1",
+			"https://scope.schema/1",
+			"CPU utilization",
+			"%",
+		)
+
+		second := makeTestGaugeMetadataRow(
+			[]*commonpb.KeyValue{
+				stringAttr("host.name", "host-a"),
+				stringAttr("service.name", "svc"),
+			},
+			[]*commonpb.KeyValue{
+				stringAttr("scope.attr.b", "b"),
+				stringAttr("scope.attr.a", "a"),
+			},
+			[]*commonpb.KeyValue{
+				stringAttr("state", "idle"),
+				stringAttr("cpu", "0"),
+			},
+			"https://resource.schema/1",
+			"https://scope.schema/1",
+			"CPU utilization",
+			"%",
+		)
+
+		if first.MetadataKey != second.MetadataKey {
+			t.Fatalf("expected reordered attributes to keep metadata key stable, got %s and %s", first.MetadataKey, second.MetadataKey)
+		}
+	})
+
+	t.Run("gauge and sum rows do not share metadata keys", func(t *testing.T) {
+		gauge := makeTestGaugeMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("method", "GET")}, "", "", "Request count", "1")
+		sum := makeTestSumMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("method", "GET")}, "", "", "Request count", "1", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true)
+
+		if gauge.MetadataKey == sum.MetadataKey {
+			t.Fatalf("expected gauge and sum metadata keys to differ, got %s", gauge.MetadataKey)
+		}
+	})
+
+	t.Run("sum semantics changes create a new identity", func(t *testing.T) {
+		base := makeTestSumMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("method", "GET")}, "", "", "Request count", "1", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, true)
+		changedTemporality := makeTestSumMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("method", "GET")}, "", "", "Request count", "1", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, true)
+		changedMonotonic := makeTestSumMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("method", "GET")}, "", "", "Request count", "1", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, false)
+
+		if base.MetadataKey == changedTemporality.MetadataKey {
+			t.Fatal("expected aggregation temporality change to create a new metadata identity")
+		}
+		if base.MetadataKey == changedMonotonic.MetadataKey {
+			t.Fatal("expected monotonicity change to create a new metadata identity")
+		}
+	})
+
+	t.Run("metric unit changes create a new gauge identity", func(t *testing.T) {
+		first := makeTestGaugeMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("cpu", "0")}, "", "", "CPU utilization", "%")
+		second := makeTestGaugeMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("cpu", "0")}, "", "", "CPU utilization", "ratio")
+
+		if first.MetadataKey == second.MetadataKey {
+			t.Fatal("expected unit change to create a new metadata identity")
+		}
+	})
+
+	t.Run("description changes keep identity but change replacement rank", func(t *testing.T) {
+		first := makeTestGaugeMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("cpu", "0")}, "", "", "CPU utilization", "%")
+		second := makeTestGaugeMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("cpu", "0")}, "", "", "CPU busy percentage", "%")
+
+		if first.MetadataKey != second.MetadataKey {
+			t.Fatal("expected description change to reuse the same metadata identity")
+		}
+		if first.ReplacementRank == second.ReplacementRank {
+			t.Fatal("expected description change to alter replacement rank")
+		}
+	})
+
+	t.Run("schema url changes keep identity but change replacement rank", func(t *testing.T) {
+		first := makeTestGaugeMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("cpu", "0")}, "https://resource.schema/1", "https://scope.schema/1", "CPU utilization", "%")
+		second := makeTestGaugeMetadataRow(nil, nil, []*commonpb.KeyValue{stringAttr("cpu", "0")}, "https://resource.schema/2", "https://scope.schema/2", "CPU utilization", "%")
+
+		if first.MetadataKey != second.MetadataKey {
+			t.Fatal("expected schema URL changes to reuse the same metadata identity")
+		}
+		if first.ReplacementRank == second.ReplacementRank {
+			t.Fatal("expected schema URL changes to alter replacement rank")
+		}
+	})
+}
+
+func makeTestGaugeMetadataRow(resourceAttrs []*commonpb.KeyValue, scopeAttrs []*commonpb.KeyValue, attrs []*commonpb.KeyValue, resourceSchemaURL string, scopeSchemaURL string, description string, unit string) MetricMetadataRow {
+	if resourceAttrs == nil {
+		resourceAttrs = []*commonpb.KeyValue{stringAttr("service.name", "svc")}
+	}
+
+	scope := &commonpb.InstrumentationScope{
+		Name:                   "test-scope",
+		Version:                "1.0.0",
+		DroppedAttributesCount: 3,
+		Attributes:             scopeAttrs,
+	}
+
+	metric := &metricspb.Metric{
+		Name:        "test.metric",
+		Description: description,
+		Unit:        unit,
+	}
+
+	return newMetricMetadataRow(
+		serviceNameFromAttrs(resourceAttrs),
+		kvToMap(resourceAttrs),
+		resourceSchemaURL,
+		scope,
+		kvToMap(scopeAttrs),
+		scopeSchemaURL,
+		metric,
+		kvToMap(attrs),
+	)
+}
+
+func makeTestSumMetadataRow(resourceAttrs []*commonpb.KeyValue, scopeAttrs []*commonpb.KeyValue, attrs []*commonpb.KeyValue, resourceSchemaURL string, scopeSchemaURL string, description string, unit string, temporality metricspb.AggregationTemporality, monotonic bool) SumMetadataRow {
+	if resourceAttrs == nil {
+		resourceAttrs = []*commonpb.KeyValue{stringAttr("service.name", "svc")}
+	}
+
+	scope := &commonpb.InstrumentationScope{
+		Name:                   "test-scope",
+		Version:                "1.0.0",
+		DroppedAttributesCount: 3,
+		Attributes:             scopeAttrs,
+	}
+
+	metric := &metricspb.Metric{
+		Name:        "test.metric",
+		Description: description,
+		Unit:        unit,
+	}
+
+	return newSumMetadataRow(
+		serviceNameFromAttrs(resourceAttrs),
+		kvToMap(resourceAttrs),
+		resourceSchemaURL,
+		scope,
+		kvToMap(scopeAttrs),
+		scopeSchemaURL,
+		metric,
+		&metricspb.Sum{AggregationTemporality: temporality, IsMonotonic: monotonic},
+		kvToMap(attrs),
+	)
+}
+
+func serviceNameFromAttrs(attrs []*commonpb.KeyValue) string {
+	for _, attr := range attrs {
+		if attr.GetKey() == "service.name" {
+			return attr.GetValue().GetStringValue()
+		}
+	}
+	return ""
+}
+
+func stringAttr(key string, value string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{
+		Key: key,
+		Value: &commonpb.AnyValue{
+			Value: &commonpb.AnyValue_StringValue{StringValue: value},
+		},
+	}
+}

--- a/otlp-metric-store-backend-go/openspec/changes/normalize-metric-metadata-storage/tasks.md
+++ b/otlp-metric-store-backend-go/openspec/changes/normalize-metric-metadata-storage/tasks.md
@@ -18,6 +18,6 @@
 
 ## 4. Validation
 
-- [ ] 4.1 Add unit tests for metadata normalization and 128-bit identity generation, including reordered-attribute, gauge-vs-sum table separation, sum-semantic-change, unit-change, description-change, and schema-URL-change cases.
-- [ ] 4.2 Update integration tests to verify both metadata tables are created, `ReplacingMergeTree` semantics, identifying metadata drift, non-identifying metadata handling, and normalized gauge and sum inserts using `FINAL` or explicit merge forcing instead of background-merge timing.
-- [ ] 4.3 Update the gRPC-to-ClickHouse integration test to assert datapoint rows reference persisted metadata correctly.
+- [x] 4.1 Add unit tests for metadata normalization and 128-bit identity generation, including reordered-attribute, gauge-vs-sum table separation, sum-semantic-change, unit-change, description-change, and schema-URL-change cases.
+- [x] 4.2 Update integration tests to verify both metadata tables are created, `ReplacingMergeTree` semantics, identifying metadata drift, non-identifying metadata handling, and normalized gauge and sum inserts using `FINAL` or explicit merge forcing instead of background-merge timing.
+- [x] 4.3 Update the gRPC-to-ClickHouse integration test to assert datapoint rows reference persisted metadata correctly.


### PR DESCRIPTION
## Summary
- add validation coverage for normalized metric metadata identity generation and replacement-rank behavior
- verify gauge and sum integration paths persist metadata separately from datapoints and join back through MetadataKey
- extend integration coverage for deterministic ReplacingMergeTree convergence and identity drift handling

## Intention
This change increases confidence in the normalized metric storage model by testing the behaviors that matter for correctness over time: stable identity for equivalent metadata, new identities for real semantic drift, and deterministic convergence when only descriptive metadata changes. It is intended to protect the new lookup-table write path from regressions without changing runtime behavior.