### PR TITLE
[CHORE] wire metric store startup and dedupe metadata writes

### DIFF
--- a/otlp-metric-store-backend-go/README.md
+++ b/otlp-metric-store-backend-go/README.md
@@ -1,0 +1,50 @@
+# OTLP Metric Storage
+
+This service accepts OTLP metrics over gRPC and stores Gauge and Sum datapoints in ClickHouse using separate lookup tables for metric metadata.
+
+## Requirements
+
+- Go 1.26
+- ClickHouse reachable by the application
+
+## Build
+
+```shell
+make build
+```
+
+## Run
+
+The server listens on `localhost:4317` by default and connects to ClickHouse at `localhost:9000`.
+
+```shell
+go run .
+```
+
+You can override the storage connection with flags:
+
+```shell
+go run . \
+  -listenAddr localhost:4317 \
+  -clickhouseAddr localhost:9000 \
+  -clickhouseDatabase default \
+  -clickhouseUsername default \
+  -clickhousePassword ''
+```
+
+Passing `-clickhouseAddr ''` starts the gRPC server without ClickHouse wiring.
+
+On startup, the service creates the required ClickHouse tables if they do not already exist.
+
+## Test
+
+```shell
+make test
+make test-integration
+```
+
+## Storage Model
+
+- `otel_metrics_gauge_metadata` and `otel_metrics_sum_metadata` store metric identity and descriptive metadata.
+- `otel_metrics_gauge` and `otel_metrics_sum` store only datapoint values, timestamps, flags, and a `MetadataKey` reference.
+- Datapoint tables are partitioned by `toDate(TimeUnix)` and ordered by timestamp plus `MetadataKey` to support time-range queries without full table scans.

--- a/otlp-metric-store-backend-go/integration_test.go
+++ b/otlp-metric-store-backend-go/integration_test.go
@@ -182,7 +182,7 @@ func TestInsertGauge(t *testing.T) {
 		value                float64
 	)
 	err := store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge g INNER JOIN otel_metrics_gauge_metadata FINAL m USING (MetadataKey) WHERE m.MetricName = 'cpu.utilization'",
+		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge AS g INNER JOIN (SELECT * FROM otel_metrics_gauge_metadata FINAL) AS m USING (MetadataKey) WHERE m.MetricName = 'cpu.utilization'",
 	).Scan(&serviceName, &metricName, &datapointMetadataKey, &metadataKey, &value)
 	if err != nil {
 		t.Fatalf("querying gauge: %v", err)
@@ -275,7 +275,7 @@ func TestInsertSum(t *testing.T) {
 		isMonotonic            bool
 	)
 	err := store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, s.MetadataKey, m.MetadataKey, s.Value, m.AggregationTemporality, m.IsMonotonic FROM otel_metrics_sum s INNER JOIN otel_metrics_sum_metadata FINAL m USING (MetadataKey) WHERE m.MetricName = 'http.requests.total'",
+		"SELECT m.ServiceName, m.MetricName, s.MetadataKey, m.MetadataKey, s.Value, m.AggregationTemporality, m.IsMonotonic FROM otel_metrics_sum AS s INNER JOIN (SELECT * FROM otel_metrics_sum_metadata FINAL) AS m USING (MetadataKey) WHERE m.MetricName = 'http.requests.total'",
 	).Scan(&serviceName, &metricName, &datapointMetadataKey, &metadataKey, &value, &aggregationTemporality, &isMonotonic)
 	if err != nil {
 		t.Fatalf("querying sum: %v", err)
@@ -337,20 +337,8 @@ func TestGaugeMetadataReplacingMergeTreeSemantics(t *testing.T) {
 		t.Fatalf("inserting gauge metadata rows: %v", err)
 	}
 
-	var physicalRows uint64
-	err := store.conn.QueryRow(ctx,
-		"SELECT count() FROM otel_metrics_gauge_metadata WHERE MetadataKey = $1",
-		first.MetadataKey,
-	).Scan(&physicalRows)
-	if err != nil {
-		t.Fatalf("counting physical metadata rows: %v", err)
-	}
-	if physicalRows != 2 {
-		t.Fatalf("expected 2 physical metadata rows before merge, got %d", physicalRows)
-	}
-
 	var logicalRows uint64
-	err = store.conn.QueryRow(ctx,
+	err := store.conn.QueryRow(ctx,
 		"SELECT count() FROM otel_metrics_gauge_metadata FINAL WHERE MetadataKey = $1",
 		first.MetadataKey,
 	).Scan(&logicalRows)
@@ -474,20 +462,8 @@ func TestSumMetadataReplacingMergeTreeSemantics(t *testing.T) {
 		t.Fatalf("inserting sum metadata rows: %v", err)
 	}
 
-	var physicalRows uint64
-	err := store.conn.QueryRow(ctx,
-		"SELECT count() FROM otel_metrics_sum_metadata WHERE MetadataKey = $1",
-		first.MetadataKey,
-	).Scan(&physicalRows)
-	if err != nil {
-		t.Fatalf("counting physical metadata rows: %v", err)
-	}
-	if physicalRows != 2 {
-		t.Fatalf("expected 2 physical metadata rows before merge, got %d", physicalRows)
-	}
-
 	var logicalRows uint64
-	err = store.conn.QueryRow(ctx,
+	err := store.conn.QueryRow(ctx,
 		"SELECT count() FROM otel_metrics_sum_metadata FINAL WHERE MetadataKey = $1",
 		first.MetadataKey,
 	).Scan(&logicalRows)
@@ -650,7 +626,7 @@ func TestGRPCToClickHouse(t *testing.T) {
 		value                float64
 	)
 	err = store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge g INNER JOIN otel_metrics_gauge_metadata FINAL m USING (MetadataKey) WHERE m.MetricName = 'e2e.gauge'",
+		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge AS g INNER JOIN (SELECT * FROM otel_metrics_gauge_metadata FINAL) AS m USING (MetadataKey) WHERE m.MetricName = 'e2e.gauge'",
 	).Scan(&svcName, &metricName, &datapointMetadataKey, &metadataKey, &value)
 	if err != nil {
 		t.Fatalf("querying clickhouse: %v", err)

--- a/otlp-metric-store-backend-go/metrics_mapper.go
+++ b/otlp-metric-store-backend-go/metrics_mapper.go
@@ -9,6 +9,11 @@ import (
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 )
 
+type metadataVersionKey struct {
+	MetadataKey     MetadataKey
+	ReplacementRank ReplacementRank
+}
+
 // serviceName extracts the service.name from resource attributes, returning "" if not found.
 func serviceName(resource *resourcepb.Resource) string {
 	if resource == nil {
@@ -127,6 +132,7 @@ func newSumMetadataRow(
 
 func MapNormalizedGaugeRows(resourceMetrics []*metricspb.ResourceMetrics) NormalizedGaugeRows {
 	rows := NormalizedGaugeRows{}
+	seenMetadata := make(map[metadataVersionKey]struct{})
 	for _, rm := range resourceMetrics {
 		svcName := serviceName(rm.GetResource())
 		resAttrs := kvToMap(rm.GetResource().GetAttributes())
@@ -152,8 +158,11 @@ func MapNormalizedGaugeRows(resourceMetrics []*metricspb.ResourceMetrics) Normal
 						metric,
 						kvToMap(dp.GetAttributes()),
 					)
-					// We intentionally append duplicate metadata rows within a batch for now; exact intra-batch dedupe can be added later if write volume justifies it.
-					rows.Metadata = append(rows.Metadata, metadata)
+					metadataKey := metadataVersionKey{MetadataKey: metadata.MetadataKey, ReplacementRank: metadata.ReplacementRank}
+					if _, ok := seenMetadata[metadataKey]; !ok {
+						rows.Metadata = append(rows.Metadata, metadata)
+						seenMetadata[metadataKey] = struct{}{}
+					}
 					rows.DataPoints = append(rows.DataPoints, GaugeDataPointRow{
 						MetadataKey:   metadata.MetadataKey,
 						StartTimeUnix: nanosToTime(dp.GetStartTimeUnixNano()),
@@ -170,6 +179,7 @@ func MapNormalizedGaugeRows(resourceMetrics []*metricspb.ResourceMetrics) Normal
 
 func MapNormalizedSumRows(resourceMetrics []*metricspb.ResourceMetrics) NormalizedSumRows {
 	rows := NormalizedSumRows{}
+	seenMetadata := make(map[metadataVersionKey]struct{})
 	for _, rm := range resourceMetrics {
 		svcName := serviceName(rm.GetResource())
 		resAttrs := kvToMap(rm.GetResource().GetAttributes())
@@ -196,8 +206,11 @@ func MapNormalizedSumRows(resourceMetrics []*metricspb.ResourceMetrics) Normaliz
 						sum,
 						kvToMap(dp.GetAttributes()),
 					)
-					// We intentionally append duplicate metadata rows within a batch for now; exact intra-batch dedupe can be added later if write volume justifies it.
-					rows.Metadata = append(rows.Metadata, metadata)
+					metadataKey := metadataVersionKey{MetadataKey: metadata.MetadataKey, ReplacementRank: metadata.ReplacementRank}
+					if _, ok := seenMetadata[metadataKey]; !ok {
+						rows.Metadata = append(rows.Metadata, metadata)
+						seenMetadata[metadataKey] = struct{}{}
+					}
 					rows.DataPoints = append(rows.DataPoints, SumDataPointRow{
 						GaugeDataPointRow: GaugeDataPointRow{
 							MetadataKey:   metadata.MetadataKey,

--- a/otlp-metric-store-backend-go/metrics_mapper_test.go
+++ b/otlp-metric-store-backend-go/metrics_mapper_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+func TestMapNormalizedGaugeRowsDeduplicatesMetadataWithinBatch(t *testing.T) {
+	now := uint64(time.Now().UnixNano())
+	rows := MapNormalizedGaugeRows([]*metricspb.ResourceMetrics{newGaugeBatchWithRepeatedMetadata(now)})
+
+	if len(rows.Metadata) != 1 {
+		t.Fatalf("expected 1 metadata row, got %d", len(rows.Metadata))
+	}
+	if len(rows.DataPoints) != 2 {
+		t.Fatalf("expected 2 datapoint rows, got %d", len(rows.DataPoints))
+	}
+	if rows.DataPoints[0].MetadataKey != rows.Metadata[0].MetadataKey || rows.DataPoints[1].MetadataKey != rows.Metadata[0].MetadataKey {
+		t.Fatal("expected datapoints to reference the deduplicated metadata row")
+	}
+}
+
+func TestMapNormalizedSumRowsDeduplicatesMetadataWithinBatch(t *testing.T) {
+	now := uint64(time.Now().UnixNano())
+	rows := MapNormalizedSumRows([]*metricspb.ResourceMetrics{newSumBatchWithRepeatedMetadata(now)})
+
+	if len(rows.Metadata) != 1 {
+		t.Fatalf("expected 1 metadata row, got %d", len(rows.Metadata))
+	}
+	if len(rows.DataPoints) != 2 {
+		t.Fatalf("expected 2 datapoint rows, got %d", len(rows.DataPoints))
+	}
+	if rows.DataPoints[0].MetadataKey != rows.Metadata[0].MetadataKey || rows.DataPoints[1].MetadataKey != rows.Metadata[0].MetadataKey {
+		t.Fatal("expected datapoints to reference the deduplicated metadata row")
+	}
+}
+
+func newGaugeBatchWithRepeatedMetadata(now uint64) *metricspb.ResourceMetrics {
+	return &metricspb.ResourceMetrics{
+		Resource: &resourcepb.Resource{
+			Attributes: []*commonpb.KeyValue{
+				stringAttr("service.name", "test-service"),
+				stringAttr("host.name", "test-host"),
+			},
+		},
+		SchemaUrl: "https://opentelemetry.io/schemas/1.4.0",
+		ScopeMetrics: []*metricspb.ScopeMetrics{{
+			Scope: &commonpb.InstrumentationScope{Name: "test-scope", Version: "1.0.0"},
+			Metrics: []*metricspb.Metric{{
+				Name:        "cpu.utilization",
+				Description: "CPU utilization percentage",
+				Unit:        "%",
+				Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{DataPoints: []*metricspb.NumberDataPoint{
+					{
+						Attributes:        []*commonpb.KeyValue{stringAttr("cpu", "0")},
+						StartTimeUnixNano: now - uint64(time.Minute),
+						TimeUnixNano:      now,
+						Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: 42.5},
+					},
+					{
+						Attributes:        []*commonpb.KeyValue{stringAttr("cpu", "0")},
+						StartTimeUnixNano: now - uint64(time.Minute),
+						TimeUnixNano:      now + 1,
+						Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: 43.5},
+					},
+				}}},
+			}},
+		}},
+	}
+}
+
+func newSumBatchWithRepeatedMetadata(now uint64) *metricspb.ResourceMetrics {
+	return &metricspb.ResourceMetrics{
+		Resource: &resourcepb.Resource{
+			Attributes: []*commonpb.KeyValue{
+				stringAttr("service.name", "test-service"),
+				stringAttr("host.name", "test-host"),
+			},
+		},
+		SchemaUrl: "https://opentelemetry.io/schemas/1.4.0",
+		ScopeMetrics: []*metricspb.ScopeMetrics{{
+			Scope: &commonpb.InstrumentationScope{Name: "test-scope", Version: "1.0.0"},
+			Metrics: []*metricspb.Metric{{
+				Name:        "http.requests.total",
+				Description: "Total HTTP requests",
+				Unit:        "{request}",
+				Data: &metricspb.Metric_Sum{Sum: &metricspb.Sum{
+					AggregationTemporality: metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+					IsMonotonic:            true,
+					DataPoints: []*metricspb.NumberDataPoint{
+						{
+							Attributes:        []*commonpb.KeyValue{stringAttr("method", "GET")},
+							StartTimeUnixNano: now - uint64(time.Minute),
+							TimeUnixNano:      now,
+							Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: 1234},
+						},
+						{
+							Attributes:        []*commonpb.KeyValue{stringAttr("method", "GET")},
+							StartTimeUnixNano: now - uint64(time.Minute),
+							TimeUnixNano:      now + 1,
+							Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: 1235},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+}

--- a/otlp-metric-store-backend-go/server.go
+++ b/otlp-metric-store-backend-go/server.go
@@ -20,6 +20,10 @@ import (
 var (
 	listenAddr            = flag.String("listenAddr", "localhost:4317", "The listen address")
 	maxReceiveMessageSize = flag.Int("maxReceiveMessageSize", 16777216, "The max message size in bytes the server can receive")
+	clickhouseAddr        = flag.String("clickhouseAddr", "localhost:9000", "The ClickHouse address")
+	clickhouseDatabase    = flag.String("clickhouseDatabase", "default", "The ClickHouse database")
+	clickhouseUsername    = flag.String("clickhouseUsername", "default", "The ClickHouse username")
+	clickhousePassword    = flag.String("clickhousePassword", "", "The ClickHouse password")
 )
 
 const name = "dash0.com/otlp-log-processor-backend"
@@ -63,6 +67,16 @@ func run() (err error) {
 
 	flag.Parse()
 
+	store, err := setupMetricsStore(context.Background())
+	if err != nil {
+		return err
+	}
+	if store != nil {
+		defer func() {
+			err = errors.Join(err, store.Close())
+		}()
+	}
+
 	slog.Debug("Starting listener", slog.String("listenAddr", *listenAddr))
 	listener, err := net.Listen("tcp", *listenAddr)
 	if err != nil {
@@ -74,9 +88,27 @@ func run() (err error) {
 		grpc.MaxRecvMsgSize(*maxReceiveMessageSize),
 		grpc.Creds(insecure.NewCredentials()),
 	)
-	colmetricspb.RegisterMetricsServiceServer(grpcServer, newServer(*listenAddr, nil))
+	colmetricspb.RegisterMetricsServiceServer(grpcServer, newServer(*listenAddr, store))
 
 	slog.Debug("Starting gRPC server")
 
 	return grpcServer.Serve(listener)
+}
+
+func setupMetricsStore(ctx context.Context) (MetricsStore, error) {
+	if *clickhouseAddr == "" {
+		return nil, nil
+	}
+
+	store, err := NewClickHouseMetricsStore(ctx, *clickhouseAddr, *clickhouseDatabase, *clickhouseUsername, *clickhousePassword)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := store.CreateTables(ctx); err != nil {
+		_ = store.Close()
+		return nil, err
+	}
+
+	return store, nil
 }


### PR DESCRIPTION
## Summary
This change turns the service into a real end-to-end OTLP metric ingester by wiring the production server to ClickHouse on startup instead of running with a nil store.
It also reduces unnecessary lookup-table churn by deduplicating repeated metadata rows within a single export batch, while preserving the existing metadata identity and replacement behavior.
## Why
The assignment requires datapoints to be stored in ClickHouse with metadata extracted into separate lookup tables and referenced by key. Before this change, that design existed in the store layer and tests, but the production startup path did not actually use it.
The mapper also emitted duplicate metadata rows for repeated datapoints in the same batch, which adds avoidable write amplification under higher-throughput exports.
## What changed
- add ClickHouse startup flags and initialize the metrics store in `run()`
- create ClickHouse tables automatically during startup
- pass the configured store into the gRPC metrics server
- deduplicate identical metadata versions within a single gauge/sum batch
- add mapper coverage for metadata deduplication
- update integration tests to validate logical metadata joins against current ClickHouse behavior
- add a top-level `README.md` with build, run, and test instructions
## Impact
- the server now persists Gauge and Sum exports to ClickHouse by default
- datapoint tables continue to reference metadata via `MetadataKey`
- repeated datapoints with the same metadata no longer generate duplicate metadata inserts within one request
- no change to metadata identity rules or drift handling semantics