### PR TITLE
[CHORE] document normalized metric query flow

### DIFF
--- a/otlp-metric-store-backend-go/README.md
+++ b/otlp-metric-store-backend-go/README.md
@@ -48,3 +48,27 @@ make test-integration
 - `otel_metrics_gauge_metadata` and `otel_metrics_sum_metadata` store metric identity and descriptive metadata.
 - `otel_metrics_gauge` and `otel_metrics_sum` store only datapoint values, timestamps, flags, and a `MetadataKey` reference.
 - Datapoint tables are partitioned by `toDate(TimeUnix)` and ordered by timestamp plus `MetadataKey` to support time-range queries without full table scans.
+
+## Query Flow
+
+Normalized reads follow a two-step contract:
+
+1. Query the metadata table to discover which series match filters such as service name, metric name, or datapoint attributes, and capture the returned `MetadataKey` values.
+2. Query the datapoint table for a time range using those `MetadataKey` values.
+
+This is a behavioral contract, not a single required SQL shape. Metadata discovery may scan metadata tables when needed; the bounded read guarantee applies to the datapoint tables once the relevant `MetadataKey` values are known.
+
+Illustrative example:
+
+```sql
+SELECT MetadataKey, ServiceName, MetricName
+FROM otel_metrics_gauge_metadata FINAL
+WHERE ServiceName = 'checkout' AND MetricName = 'http.server.duration';
+
+SELECT TimeUnix, Value, Flags
+FROM otel_metrics_gauge
+WHERE MetadataKey IN (<selected keys>)
+  AND TimeUnix >= toDateTime64('2026-05-03 10:00:00', 9)
+  AND TimeUnix <= toDateTime64('2026-05-03 11:00:00', 9)
+ORDER BY TimeUnix;
+```

--- a/otlp-metric-store-backend-go/integration_test.go
+++ b/otlp-metric-store-backend-go/integration_test.go
@@ -177,15 +177,27 @@ func TestInsertGauge(t *testing.T) {
 	var (
 		serviceName          string
 		metricName           string
-		datapointMetadataKey MetadataKey
 		metadataKey          MetadataKey
+		datapointMetadataKey MetadataKey
 		value                float64
 	)
 	err := store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge AS g INNER JOIN (SELECT * FROM otel_metrics_gauge_metadata FINAL) AS m USING (MetadataKey) WHERE m.MetricName = 'cpu.utilization'",
-	).Scan(&serviceName, &metricName, &datapointMetadataKey, &metadataKey, &value)
+		"SELECT MetadataKey, ServiceName, MetricName FROM otel_metrics_gauge_metadata FINAL WHERE MetricName = $1 AND ServiceName = $2",
+		"cpu.utilization",
+		"test-service",
+	).Scan(&metadataKey, &serviceName, &metricName)
 	if err != nil {
-		t.Fatalf("querying gauge: %v", err)
+		t.Fatalf("querying gauge metadata: %v", err)
+	}
+
+	err = store.conn.QueryRow(ctx,
+		"SELECT MetadataKey, Value FROM otel_metrics_gauge WHERE MetadataKey = $1 AND TimeUnix >= fromUnixTimestamp64Nano($2) AND TimeUnix <= fromUnixTimestamp64Nano($3)",
+		metadataKey,
+		int64(startTime),
+		int64(now),
+	).Scan(&datapointMetadataKey, &value)
+	if err != nil {
+		t.Fatalf("querying gauge datapoints: %v", err)
 	}
 
 	if serviceName != "test-service" {
@@ -268,17 +280,29 @@ func TestInsertSum(t *testing.T) {
 	var (
 		serviceName            string
 		metricName             string
-		datapointMetadataKey   MetadataKey
 		metadataKey            MetadataKey
+		datapointMetadataKey   MetadataKey
 		value                  float64
 		aggregationTemporality int32
 		isMonotonic            bool
 	)
 	err := store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, s.MetadataKey, m.MetadataKey, s.Value, m.AggregationTemporality, m.IsMonotonic FROM otel_metrics_sum AS s INNER JOIN (SELECT * FROM otel_metrics_sum_metadata FINAL) AS m USING (MetadataKey) WHERE m.MetricName = 'http.requests.total'",
-	).Scan(&serviceName, &metricName, &datapointMetadataKey, &metadataKey, &value, &aggregationTemporality, &isMonotonic)
+		"SELECT MetadataKey, ServiceName, MetricName, AggregationTemporality, IsMonotonic FROM otel_metrics_sum_metadata FINAL WHERE MetricName = $1 AND ServiceName = $2",
+		"http.requests.total",
+		"test-service",
+	).Scan(&metadataKey, &serviceName, &metricName, &aggregationTemporality, &isMonotonic)
 	if err != nil {
-		t.Fatalf("querying sum: %v", err)
+		t.Fatalf("querying sum metadata: %v", err)
+	}
+
+	err = store.conn.QueryRow(ctx,
+		"SELECT MetadataKey, Value FROM otel_metrics_sum WHERE MetadataKey = $1 AND TimeUnix >= fromUnixTimestamp64Nano($2) AND TimeUnix <= fromUnixTimestamp64Nano($3)",
+		metadataKey,
+		int64(startTime),
+		int64(now),
+	).Scan(&datapointMetadataKey, &value)
+	if err != nil {
+		t.Fatalf("querying sum datapoints: %v", err)
 	}
 
 	if serviceName != "test-service" {
@@ -621,15 +645,27 @@ func TestGRPCToClickHouse(t *testing.T) {
 	var (
 		svcName              string
 		metricName           string
-		datapointMetadataKey MetadataKey
 		metadataKey          MetadataKey
+		datapointMetadataKey MetadataKey
 		value                float64
 	)
 	err = store.conn.QueryRow(ctx,
-		"SELECT m.ServiceName, m.MetricName, g.MetadataKey, m.MetadataKey, g.Value FROM otel_metrics_gauge AS g INNER JOIN (SELECT * FROM otel_metrics_gauge_metadata FINAL) AS m USING (MetadataKey) WHERE m.MetricName = 'e2e.gauge'",
-	).Scan(&svcName, &metricName, &datapointMetadataKey, &metadataKey, &value)
+		"SELECT MetadataKey, ServiceName, MetricName FROM otel_metrics_gauge_metadata FINAL WHERE MetricName = $1 AND ServiceName = $2",
+		"e2e.gauge",
+		"e2e-service",
+	).Scan(&metadataKey, &svcName, &metricName)
 	if err != nil {
-		t.Fatalf("querying clickhouse: %v", err)
+		t.Fatalf("querying clickhouse metadata: %v", err)
+	}
+
+	err = store.conn.QueryRow(ctx,
+		"SELECT MetadataKey, Value FROM otel_metrics_gauge WHERE MetadataKey = $1 AND TimeUnix >= fromUnixTimestamp64Nano($2) AND TimeUnix <= fromUnixTimestamp64Nano($3)",
+		metadataKey,
+		int64(now-uint64(time.Second)),
+		int64(now+uint64(time.Second)),
+	).Scan(&datapointMetadataKey, &value)
+	if err != nil {
+		t.Fatalf("querying clickhouse datapoints: %v", err)
 	}
 	if svcName != "e2e-service" {
 		t.Errorf("expected ServiceName=e2e-service, got %s", svcName)

--- a/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/.openspec.yaml
+++ b/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/design.md
+++ b/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The current normalized schema cleanly separates datapoints from metadata, and the datapoint tables are already partitioned and ordered for time-range pruning. The ambiguity is not the write path or schema shape, but the read flow: some queries need metadata first to identify which metric series are relevant, and only then can they fetch datapoints for those series.
+
+This change is limited to the normalized gauge and sum storage model. It must preserve append-only metadata writes, `ReplacingMergeTree` replacement semantics, and compact metadata identity generation while making the supported read pattern explicit and testable. It should avoid speculative schema changes until there is evidence that metadata discovery itself is a bottleneck.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Clarify the supported normalized query flow for the common case where callers identify matching metric series before fetching datapoints.
+- Guarantee that once the relevant `MetadataKey` values are known, datapoint retrieval remains time-bounded on the datapoint tables.
+- Preserve the existing metadata identity model and `ReplacingMergeTree` deduplication behavior.
+- Document the two-step behavioral contract and include one illustrative query example without requiring a single exact SQL shape.
+
+**Non-Goals:**
+- Adding a public read API to the gRPC service.
+- Repartitioning metadata tables by time or storing duplicate time columns in metadata rows.
+- Adding new metadata-side indexes, materialized views, or helper tables before real query workloads justify them.
+- Promising that metadata discovery queries will never scan metadata tables.
+
+## Decisions
+
+### Decision: Support metadata-first series discovery
+Normalized reads will explicitly allow a first step that queries the metadata tables to discover which series match filters such as metric name, service name, or datapoint attributes. That step returns the relevant logical metadata rows and their `MetadataKey` values, which the caller can then use to fetch datapoints.
+
+Alternatives considered:
+- Force every read to start from datapoints: rejected because it does not match the common query flow where users need to know which series exist before asking for datapoints.
+- Keep the current ad hoc join examples: rejected because they demonstrate correctness of joins but do not describe the intended two-step flow.
+
+### Decision: Keep datapoint retrieval bounded after series selection
+After the relevant `MetadataKey` values have been identified, datapoint queries will use those keys together with the requested time predicate to read only the relevant partitions and rows from the datapoint tables. This keeps the existing time-range guarantee where it matters most: on the high-volume datapoint tables.
+
+Alternatives considered:
+- Add event-time columns and partitions to metadata tables: rejected because metadata rows do not have stable datapoint-time semantics and this would complicate replacement behavior.
+- Add secondary indexes for every likely metadata filter field now: rejected as premature optimization without evidence of a real metadata-discovery bottleneck.
+
+### Decision: Capture the contract in documentation and focused tests
+The implementation should document the two-step query flow and add focused integration coverage that exercises it end to end. The documentation will describe the behavioral contract, include one illustrative series-discovery example, and avoid prescribing a single mandatory SQL form. The first implementation will keep the flow expressed directly in integration tests and documentation rather than extracting a shared SQL helper before a real read API exists.
+
+Alternatives considered:
+- Add a new production read layer up front: rejected because the service does not yet expose a read API and that would be unnecessary design work.
+- Assert exact ClickHouse physical plans: rejected because it would optimize for implementation detail rather than the behavior we need to guarantee.
+
+## Risks / Trade-offs
+
+- [Metadata discovery may scan the metadata tables] -> Accept this for now because metadata volume is lower than datapoint volume, and revisit only if measured workloads show a problem.
+- [Two-step reads require callers to carry `MetadataKey` values between steps] -> Document the flow clearly and add integration examples that show the expected handoff.
+- [The implementation could grow into a premature read abstraction] -> Keep the change scoped to docs, tests, and only the smallest helper extraction if repetition makes it worthwhile.
+
+## Migration Plan
+
+1. Update the spec delta to distinguish metadata discovery from time-bounded datapoint retrieval.
+2. Add or update query examples in tests or docs so the two-step flow is concrete without freezing one exact SQL shape.
+3. Extend integration coverage and storage documentation to verify and explain the supported query pattern.
+4. Revisit metadata-side optimizations only if real usage demonstrates a bottleneck.

--- a/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/proposal.md
+++ b/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The normalized storage design currently leaves the read path ambiguous: users often need to discover which metric series match a metadata filter before they can fetch datapoints, but the repository does not yet describe that flow explicitly. This change is needed to clarify the supported query pattern without overengineering the schema or adding premature metadata-side optimizations.
+
+## What Changes
+
+- Clarify the normalized query contract as a two-step flow: discover matching series metadata and `MetadataKey` values first, then fetch time-bounded datapoints for those keys.
+- Tighten the datapoint-read requirements so time-bounded retrieval remains bounded on the datapoint tables after the relevant metadata keys have been selected.
+- Add focused documentation and integration coverage for the supported query flow without changing the storage schema or introducing speculative indexes, materialized views, or a new read API.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `metric-metadata-lookup`: Clarify how normalized reads discover matching metadata first and then use the resulting `MetadataKey` set for time-bounded datapoint retrieval.
+
+## Impact
+
+- Affected code: `integration_test.go`, `README.md`, and any shared SQL helpers if the implementation chooses to add them.
+- Affected systems: ClickHouse query patterns for normalized gauge and sum reads.
+- API impact: no gRPC API contract changes; this clarifies the supported read flow for normalized storage.
+- Operational impact: tests and docs must show how metadata discovery and datapoint retrieval work together without introducing premature storage optimizations.

--- a/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/specs/metric-metadata-lookup/spec.md
+++ b/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/specs/metric-metadata-lookup/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Support metadata-first series discovery
+The system SHALL allow normalized gauge and sum reads to discover matching metric series from the metadata lookup tables before fetching datapoints. The discovery step SHALL return the logical metadata rows and their `MetadataKey` values without requiring datapoint rows to duplicate the metadata payload inline.
+
+#### Scenario: Query identifies matching metric series before fetching datapoints
+- **WHEN** a query filters by metric, resource, scope, service, or datapoint attribute metadata and needs to know which series exist
+- **THEN** the system MUST be able to return matching metadata rows together with their `MetadataKey` values for a later datapoint query
+
+## MODIFIED Requirements
+
+### Requirement: Keep datapoint storage optimized for time-bounded queries
+The system SHALL store gauge and sum datapoints in time-partitioned tables and SHALL support fetching datapoints for a specified time range, optionally constrained by a previously selected set of `MetadataKey` values, without requiring full table scans of all datapoints.
+
+#### Scenario: Datapoint tables remain partitioned by event date
+- **WHEN** the ClickHouse schema is created for normalized datapoint storage
+- **THEN** the gauge and sum datapoint tables MUST partition rows using the datapoint event time
+
+#### Scenario: Datapoint rows do not duplicate full metadata payloads
+- **WHEN** a normalized datapoint row is persisted
+- **THEN** the row MUST contain the datapoint value fields and a metadata reference instead of repeating the full metadata maps and descriptive fields inline
+
+#### Scenario: Time-bounded datapoint reads use selected metadata keys
+- **WHEN** a gauge or sum query fetches datapoints for a specific time range after determining a relevant set of `MetadataKey` values
+- **THEN** the query MUST apply the requested time predicate to the datapoint table and use those `MetadataKey` values to constrain the datapoint rows it reads
+
+#### Scenario: Supported normalized query flow is documented and verifiable
+- **WHEN** the repository defines the normalized query path for gauge or sum reads
+- **THEN** the documented or shared query pattern MUST make the metadata-discovery step and the time-bounded datapoint retrieval step explicit so integration tests can verify the intended flow

--- a/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/tasks.md
+++ b/otlp-metric-store-backend-go/openspec/changes/archive/2026-05-03-avoid-metadata-full-scans/tasks.md
@@ -1,0 +1,14 @@
+## 1. Clarify the normalized query flow
+
+- [x] 1.1 Document the two-step normalized read flow: discover matching metadata and `MetadataKey` values first, then fetch datapoints for those keys within a time range.
+- [x] 1.2 Keep the first implementation flow explicit in integration test queries and documentation instead of extracting a shared SQL helper.
+
+## 2. Verify the supported query behavior
+
+- [x] 2.1 Add integration coverage that queries metadata first to identify matching gauge and sum series and captures their `MetadataKey` values.
+- [x] 2.2 Add integration coverage that fetches datapoints for a time range using those selected `MetadataKey` values and verifies the expected rows are returned.
+
+## 3. Validate the scoped change
+
+- [x] 3.1 Update `README.md` to explain the behavioral contract, distinguish metadata-discovery queries from time-bounded datapoint reads, and include one illustrative query example.
+- [x] 3.2 Run `make test` and `make test-integration` to validate the updated documentation assumptions and integration coverage.

--- a/otlp-metric-store-backend-go/openspec/specs/metric-metadata-lookup/spec.md
+++ b/otlp-metric-store-backend-go/openspec/specs/metric-metadata-lookup/spec.md
@@ -79,8 +79,15 @@ The system SHALL use metadata storage strategies for the gauge and sum metadata 
 - **WHEN** duplicate metadata rows exist for the same identity with different non-identifying metadata values
 - **THEN** the system MUST apply a deterministic whole-row replacement policy derived from canonical non-identifying metadata so the surviving logical metadata record is predictable independent of insert order
 
+### Requirement: Support metadata-first series discovery
+The system SHALL allow normalized gauge and sum reads to discover matching metric series from the metadata lookup tables before fetching datapoints. The discovery step SHALL return the logical metadata rows and their `MetadataKey` values without requiring datapoint rows to duplicate the metadata payload inline.
+
+#### Scenario: Query identifies matching metric series before fetching datapoints
+- **WHEN** a query filters by metric, resource, scope, service, or datapoint attribute metadata and needs to know which series exist
+- **THEN** the system MUST be able to return matching metadata rows together with their `MetadataKey` values for a later datapoint query
+
 ### Requirement: Keep datapoint storage optimized for time-bounded queries
-The system SHALL store gauge and sum datapoints in time-partitioned tables that can be queried efficiently for a specified time range without requiring full table scans of all datapoints.
+The system SHALL store gauge and sum datapoints in time-partitioned tables and SHALL support fetching datapoints for a specified time range, optionally constrained by a previously selected set of `MetadataKey` values, without requiring full table scans of all datapoints.
 
 #### Scenario: Datapoint tables remain partitioned by event date
 - **WHEN** the ClickHouse schema is created for normalized datapoint storage
@@ -89,3 +96,11 @@ The system SHALL store gauge and sum datapoints in time-partitioned tables that 
 #### Scenario: Datapoint rows do not duplicate full metadata payloads
 - **WHEN** a normalized datapoint row is persisted
 - **THEN** the row MUST contain the datapoint value fields and a metadata reference instead of repeating the full metadata maps and descriptive fields inline
+
+#### Scenario: Time-bounded datapoint reads use selected metadata keys
+- **WHEN** a gauge or sum query fetches datapoints for a specific time range after determining a relevant set of `MetadataKey` values
+- **THEN** the query MUST apply the requested time predicate to the datapoint table and use those `MetadataKey` values to constrain the datapoint rows it reads
+
+#### Scenario: Supported normalized query flow is documented and verifiable
+- **WHEN** the repository defines the normalized query path for gauge or sum reads
+- **THEN** the documented or shared query pattern MUST make the metadata-discovery step and the time-bounded datapoint retrieval step explicit so integration tests can verify the intended flow


### PR DESCRIPTION
This pull request clarifies and documents the supported normalized query flow for metric reads in the OTLP metric store backend, focusing on making the two-step pattern (metadata discovery followed by time-bounded datapoint retrieval) explicit and testable. It updates documentation, specifications, and integration tests to reflect this contract, without changing the storage schema or introducing premature optimizations.

**Documentation and Spec Updates:**

* Added a new section in `README.md` describing the two-step query flow: first, discover matching series and `MetadataKey` values via metadata tables; then, fetch datapoints for those keys within a time range. Includes an illustrative SQL example.
* Expanded the specification (`spec.md`) and requirements to explicitly support metadata-first series discovery, detail how time-bounded datapoint reads use selected metadata keys, and require documentation and verifiable integration coverage of the flow. [[1]](diffhunk://#diff-3fd82b2acb5daa29ee686c64ca2a04ce92a6381e5fbf46a71ed19d5cd0d033bbR1-R29) [[2]](diffhunk://#diff-155b6b4a68ffe36f7847a012bfc812a3a537a621afdb42cb7f3527b911164f49R82-R90) [[3]](diffhunk://#diff-155b6b4a68ffe36f7847a012bfc812a3a537a621afdb42cb7f3527b911164f49R99-R106)
* Added a design document, proposal, and task list in the openspec archive to capture the motivation, goals, decisions, and migration plan for this change. [[1]](diffhunk://#diff-71fa68350e37464e41cba2fa9fa25e84042f61c7311bb78c529beaa5cec13fbeR1-R55) [[2]](diffhunk://#diff-8927e992c70f9af9042aefd7ec0e5c1492ca1166770a2020b2ec792dec118532R1-R23) [[3]](diffhunk://#diff-52b3141f2fea6339480a4278772798dcae61767ae28e03473828a585dc07c82fR1-R14) [[4]](diffhunk://#diff-db230bef672bc6a40e7eebf4734ea0936a3dcba2ff72d2f40e1705e6ffa51dc4R1-R2)

**Integration Test Improvements:**

* Refactored integration tests (`integration_test.go`) for gauge and sum metrics to explicitly query metadata tables first to obtain `MetadataKey` values, then query datapoints using those keys and a time range, matching the documented contract. Improved error messages for clarity. [[1]](diffhunk://#diff-4ec1155d87f4d0d3429f232b0b30aeba4698338e4ff0a02b37daf086ec81556fL180-R200) [[2]](diffhunk://#diff-4ec1155d87f4d0d3429f232b0b30aeba4698338e4ff0a02b37daf086ec81556fL271-R305) [[3]](diffhunk://#diff-4ec1155d87f4d0d3429f232b0b30aeba4698338e4ff0a02b37daf086ec81556fL624-R668)

These changes make the expected query pattern explicit, improve test coverage, and lay groundwork for future optimizations only if real workloads require them.