### PR TITLE
[CHORE] improve normalized metric ingestion throughput

### DIFF
--- a/otlp-metric-store-backend-go/README.md
+++ b/otlp-metric-store-backend-go/README.md
@@ -49,6 +49,16 @@ make test-integration
 - `otel_metrics_gauge` and `otel_metrics_sum` store only datapoint values, timestamps, flags, and a `MetadataKey` reference.
 - Datapoint tables are partitioned by `toDate(TimeUnix)` and ordered by timestamp plus `MetadataKey` to support time-range queries without full table scans.
 
+## Write Flow
+
+Normalized writes stay synchronous and request-scoped:
+
+1. The server maps one export request into normalized gauge and sum batches.
+2. Each populated metric kind writes one metadata batch and one datapoint batch for that request.
+3. Gauge and sum pipelines may run independently when both kinds are present, but each kind still writes metadata before datapoints.
+
+This is a scoped throughput improvement, not a broader ingestion redesign. The service does not currently provide background buffering, cross-request batching, retries, idempotent replay handling, or transactional all-or-nothing guarantees across tables or metric kinds. If a storage write fails, the export call fails, and rows written earlier in the same request may already be persisted.
+
 ## Query Flow
 
 Normalized reads follow a two-step contract:

--- a/otlp-metric-store-backend-go/metrics_service.go
+++ b/otlp-metric-store-backend-go/metrics_service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"sync"
 
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 )
@@ -24,20 +25,40 @@ func (m *dash0MetricsServiceServer) Export(ctx context.Context, request *colmetr
 
 	if m.store != nil {
 		rm := request.GetResourceMetrics()
+		gaugeRows := MapNormalizedGaugeRows(rm)
+		sumRows := MapNormalizedSumRows(rm)
 
-		if gaugeRows := MapNormalizedGaugeRows(rm); len(gaugeRows.DataPoints) > 0 {
-			if err := m.store.InsertGaugeMetadata(ctx, gaugeRows.Metadata); err != nil {
-				return nil, err
-			}
-			if err := m.store.InsertGaugeDataPoints(ctx, gaugeRows.DataPoints); err != nil {
-				return nil, err
-			}
+		var wg sync.WaitGroup
+		errCh := make(chan error, 2)
+
+		if len(gaugeRows.DataPoints) > 0 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := m.store.InsertGaugeMetadata(ctx, gaugeRows.Metadata); err != nil {
+					errCh <- err
+					return
+				}
+				errCh <- m.store.InsertGaugeDataPoints(ctx, gaugeRows.DataPoints)
+			}()
 		}
-		if sumRows := MapNormalizedSumRows(rm); len(sumRows.DataPoints) > 0 {
-			if err := m.store.InsertSumMetadata(ctx, sumRows.Metadata); err != nil {
-				return nil, err
-			}
-			if err := m.store.InsertSumDataPoints(ctx, sumRows.DataPoints); err != nil {
+		if len(sumRows.DataPoints) > 0 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := m.store.InsertSumMetadata(ctx, sumRows.Metadata); err != nil {
+					errCh <- err
+					return
+				}
+				errCh <- m.store.InsertSumDataPoints(ctx, sumRows.DataPoints)
+			}()
+		}
+
+		wg.Wait()
+		close(errCh)
+
+		for err := range errCh {
+			if err != nil {
 				return nil, err
 			}
 		}

--- a/otlp-metric-store-backend-go/metrics_service_test.go
+++ b/otlp-metric-store-backend-go/metrics_service_test.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+type fakeMetricsStore struct {
+	mu sync.Mutex
+
+	calls []string
+
+	gaugeMetadataBatchSizes  []int
+	gaugeDataPointBatchSizes []int
+	sumMetadataBatchSizes    []int
+	sumDataPointBatchSizes   []int
+
+	insertGaugeMetadata   func(context.Context, []MetricMetadataRow) error
+	insertGaugeDataPoints func(context.Context, []GaugeDataPointRow) error
+	insertSumMetadata     func(context.Context, []SumMetadataRow) error
+	insertSumDataPoints   func(context.Context, []SumDataPointRow) error
+}
+
+func (s *fakeMetricsStore) CreateTables(context.Context) error {
+	return nil
+}
+
+func (s *fakeMetricsStore) InsertGaugeMetadata(ctx context.Context, rows []MetricMetadataRow) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, "gauge_metadata")
+	s.gaugeMetadataBatchSizes = append(s.gaugeMetadataBatchSizes, len(rows))
+	hook := s.insertGaugeMetadata
+	s.mu.Unlock()
+
+	if hook != nil {
+		return hook(ctx, rows)
+	}
+
+	return nil
+}
+
+func (s *fakeMetricsStore) InsertGaugeDataPoints(ctx context.Context, rows []GaugeDataPointRow) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, "gauge_datapoints")
+	s.gaugeDataPointBatchSizes = append(s.gaugeDataPointBatchSizes, len(rows))
+	hook := s.insertGaugeDataPoints
+	s.mu.Unlock()
+
+	if hook != nil {
+		return hook(ctx, rows)
+	}
+
+	return nil
+}
+
+func (s *fakeMetricsStore) InsertSumMetadata(ctx context.Context, rows []SumMetadataRow) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, "sum_metadata")
+	s.sumMetadataBatchSizes = append(s.sumMetadataBatchSizes, len(rows))
+	hook := s.insertSumMetadata
+	s.mu.Unlock()
+
+	if hook != nil {
+		return hook(ctx, rows)
+	}
+
+	return nil
+}
+
+func (s *fakeMetricsStore) InsertSumDataPoints(ctx context.Context, rows []SumDataPointRow) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, "sum_datapoints")
+	s.sumDataPointBatchSizes = append(s.sumDataPointBatchSizes, len(rows))
+	hook := s.insertSumDataPoints
+	s.mu.Unlock()
+
+	if hook != nil {
+		return hook(ctx, rows)
+	}
+
+	return nil
+}
+
+func (s *fakeMetricsStore) Close() error {
+	return nil
+}
+
+func TestMetricsServiceServer_ExportPersistsGaugeInOneBatch(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeMetricsStore{}
+	server := &dash0MetricsServiceServer{store: store}
+
+	_, err := server.Export(context.Background(), testExportRequest(true, false))
+	if err != nil {
+		t.Fatalf("exporting gauge request: %v", err)
+	}
+
+	assertBatchSizes(t, store.gaugeMetadataBatchSizes, []int{1}, "gauge metadata")
+	assertBatchSizes(t, store.gaugeDataPointBatchSizes, []int{1}, "gauge datapoints")
+	assertBatchSizes(t, store.sumMetadataBatchSizes, nil, "sum metadata")
+	assertBatchSizes(t, store.sumDataPointBatchSizes, nil, "sum datapoints")
+}
+
+func TestMetricsServiceServer_ExportPersistsSumInOneBatch(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeMetricsStore{}
+	server := &dash0MetricsServiceServer{store: store}
+
+	_, err := server.Export(context.Background(), testExportRequest(false, true))
+	if err != nil {
+		t.Fatalf("exporting sum request: %v", err)
+	}
+
+	assertBatchSizes(t, store.gaugeMetadataBatchSizes, nil, "gauge metadata")
+	assertBatchSizes(t, store.gaugeDataPointBatchSizes, nil, "gauge datapoints")
+	assertBatchSizes(t, store.sumMetadataBatchSizes, []int{1}, "sum metadata")
+	assertBatchSizes(t, store.sumDataPointBatchSizes, []int{1}, "sum datapoints")
+}
+
+func TestMetricsServiceServer_ExportSkipsEmptyKinds(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeMetricsStore{}
+	server := &dash0MetricsServiceServer{store: store}
+
+	_, err := server.Export(context.Background(), testExportRequest(false, false))
+	if err != nil {
+		t.Fatalf("exporting empty request: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	if len(store.calls) != 0 {
+		t.Fatalf("expected no store calls for empty request, got %v", store.calls)
+	}
+}
+
+func TestMetricsServiceServer_ExportRunsKindsIndependently(t *testing.T) {
+	t.Parallel()
+
+	gaugeStarted := make(chan struct{})
+	sumStarted := make(chan struct{})
+	releaseWrites := make(chan struct{})
+
+	store := &fakeMetricsStore{
+		insertGaugeMetadata: func(context.Context, []MetricMetadataRow) error {
+			close(gaugeStarted)
+			<-releaseWrites
+			return nil
+		},
+		insertSumMetadata: func(context.Context, []SumMetadataRow) error {
+			close(sumStarted)
+			<-releaseWrites
+			return nil
+		},
+	}
+	server := &dash0MetricsServiceServer{store: store}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := server.Export(context.Background(), testExportRequest(true, true))
+		done <- err
+	}()
+
+	waitForSignal(t, gaugeStarted, "gauge metadata start")
+	waitForSignal(t, sumStarted, "sum metadata start")
+	close(releaseWrites)
+
+	if err := waitForExport(t, done); err != nil {
+		t.Fatalf("exporting mixed request: %v", err)
+	}
+
+	assertCallBefore(t, store.calls, "gauge_metadata", "gauge_datapoints")
+	assertCallBefore(t, store.calls, "sum_metadata", "sum_datapoints")
+}
+
+func TestMetricsServiceServer_ExportReturnsMetadataErrorWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("gauge metadata failed")
+	store := &fakeMetricsStore{
+		insertGaugeMetadata: func(context.Context, []MetricMetadataRow) error {
+			return wantErr
+		},
+	}
+	server := &dash0MetricsServiceServer{store: store}
+
+	_, err := server.Export(context.Background(), testExportRequest(true, false))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+
+	assertBatchSizes(t, store.gaugeMetadataBatchSizes, []int{1}, "gauge metadata")
+	assertBatchSizes(t, store.gaugeDataPointBatchSizes, nil, "gauge datapoints")
+}
+
+func TestMetricsServiceServer_ExportAllowsPartialPersistenceAcrossKinds(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("sum datapoints failed")
+	gaugeDataPointsWritten := make(chan struct{})
+
+	store := &fakeMetricsStore{
+		insertGaugeDataPoints: func(context.Context, []GaugeDataPointRow) error {
+			close(gaugeDataPointsWritten)
+			return nil
+		},
+		insertSumMetadata: func(context.Context, []SumMetadataRow) error {
+			<-gaugeDataPointsWritten
+			return nil
+		},
+		insertSumDataPoints: func(context.Context, []SumDataPointRow) error {
+			<-gaugeDataPointsWritten
+			return wantErr
+		},
+	}
+	server := &dash0MetricsServiceServer{store: store}
+
+	_, err := server.Export(context.Background(), testExportRequest(true, true))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+
+	assertBatchSizes(t, store.gaugeMetadataBatchSizes, []int{1}, "gauge metadata")
+	assertBatchSizes(t, store.gaugeDataPointBatchSizes, []int{1}, "gauge datapoints")
+	assertBatchSizes(t, store.sumMetadataBatchSizes, []int{1}, "sum metadata")
+	assertBatchSizes(t, store.sumDataPointBatchSizes, []int{1}, "sum datapoints")
+	assertCallBefore(t, store.calls, "gauge_datapoints", "sum_datapoints")
+}
+
+func testExportRequest(includeGauge bool, includeSum bool) *colmetricspb.ExportMetricsServiceRequest {
+	const (
+		start = uint64(1_000_000_000)
+		now   = uint64(2_000_000_000)
+	)
+
+	metrics := make([]*metricspb.Metric, 0, 2)
+	if includeGauge {
+		metrics = append(metrics, &metricspb.Metric{
+			Name:        "cpu.utilization",
+			Description: "CPU utilization percentage",
+			Unit:        "%",
+			Data: &metricspb.Metric_Gauge{
+				Gauge: &metricspb.Gauge{
+					DataPoints: []*metricspb.NumberDataPoint{{
+						Attributes:        []*commonpb.KeyValue{testStringAttr("cpu", "0")},
+						StartTimeUnixNano: start,
+						TimeUnixNano:      now,
+						Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: 42.5},
+					}},
+				},
+			},
+		})
+	}
+	if includeSum {
+		metrics = append(metrics, &metricspb.Metric{
+			Name:        "http.requests.total",
+			Description: "Total HTTP requests",
+			Unit:        "{request}",
+			Data: &metricspb.Metric_Sum{
+				Sum: &metricspb.Sum{
+					AggregationTemporality: metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+					IsMonotonic:            true,
+					DataPoints: []*metricspb.NumberDataPoint{{
+						Attributes: []*commonpb.KeyValue{
+							testStringAttr("method", "GET"),
+							testStringAttr("status", "200"),
+						},
+						StartTimeUnixNano: start,
+						TimeUnixNano:      now,
+						Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: 1234},
+					}},
+				},
+			},
+		})
+	}
+
+	return &colmetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricspb.ResourceMetrics{{
+			Resource: &resourcepb.Resource{
+				Attributes: []*commonpb.KeyValue{
+					testStringAttr("service.name", "test-service"),
+					testStringAttr("host.name", "test-host"),
+				},
+			},
+			SchemaUrl: "https://opentelemetry.io/schemas/1.4.0",
+			ScopeMetrics: []*metricspb.ScopeMetrics{{
+				Scope: &commonpb.InstrumentationScope{
+					Name:    "test-scope",
+					Version: "1.0.0",
+				},
+				Metrics: metrics,
+			}},
+		}},
+	}
+}
+
+func testStringAttr(key string, value string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: key, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: value}}}
+}
+
+func assertBatchSizes(t *testing.T, got []int, want []int, name string) {
+	t.Helper()
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected %s batches: want %v, got %v", name, want, got)
+	}
+}
+
+func assertCallBefore(t *testing.T, calls []string, first string, second string) {
+	t.Helper()
+
+	firstIndex := slices.Index(calls, first)
+	secondIndex := slices.Index(calls, second)
+	if firstIndex == -1 || secondIndex == -1 {
+		t.Fatalf("missing calls in sequence %v: %s index=%d, %s index=%d", calls, first, firstIndex, second, secondIndex)
+	}
+	if firstIndex > secondIndex {
+		t.Fatalf("expected %s before %s, got %v", first, second, calls)
+	}
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func waitForExport(t *testing.T, done <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for export")
+		return nil
+	}
+}

--- a/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/.openspec.yaml
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/design.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The current export path maps normalized gauge rows and writes them to ClickHouse before doing the same for sum rows. Each populated kind already benefits from request-scoped batching and mapper-level metadata deduplication, but mixed requests still serialize the two kinds even though they target separate tables and do not depend on each other.
+
+This change is intentionally narrow. The repository is not ready to take on async buffering, cross-request write coalescing, retry queues, idempotency keys, or transactional coordination across metadata and datapoint tables. The immediate goal is to improve the throughput ceiling of one export request while keeping the write model simple, synchronous, and easy to verify in unit and integration tests.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve the existing per-request batch insert model for normalized gauge and sum ingestion.
+- Allow gauge and sum persistence work for the same export request to proceed independently when both kinds are present.
+- Keep the existing per-kind ordering guarantee that metadata is inserted before datapoints for that kind.
+- Make the write-path failure semantics explicit so tests and future changes do not assume retries or atomicity that the service does not provide.
+
+**Non-Goals:**
+- Adding background workers, async buffers, or cross-request batching.
+- Adding retry, replay, or idempotency mechanisms.
+- Providing all-or-nothing transactional guarantees across metadata and datapoint tables or across gauge and sum kinds.
+- Changing the OTLP/gRPC API surface or introducing a public read/write coordination layer.
+
+## Decisions
+
+### Decision: Split one export into independent per-kind persistence pipelines
+The export handler will continue to derive normalized rows for gauge and sum data, but once those batches are prepared it will treat each populated kind as its own persistence pipeline. A gauge pipeline performs gauge metadata insert followed by gauge datapoint insert. A sum pipeline performs sum metadata insert followed by sum datapoint insert.
+
+When both pipelines are present, they should run independently so one kind does not need to wait for the other kind to finish before beginning storage work. This is the smallest useful throughput improvement because the two kinds already target separate tables and share no write-time dependency.
+
+Alternatives considered:
+- Keep full serialization across kinds: rejected because it leaves throughput on the table for mixed requests without adding any safety guarantee.
+- Introduce finer-grained parallelism inside one kind: rejected because metadata must remain ahead of datapoints for that kind, and more granular concurrency would add complexity faster than value.
+
+### Decision: Keep per-kind sequencing and current request-scoped batching
+Within each kind, the service will continue to write one metadata batch and one datapoint batch per request, in that order. This preserves the existing mental model and keeps the `MetadataKey` reference flow straightforward.
+
+Alternatives considered:
+- Write datapoints before metadata: rejected because it weakens the normalized storage contract and makes partial-write behavior harder to reason about.
+- Split one kind into multiple smaller batches within the export handler: rejected because it does not address the current bottleneck and would complicate tests and store interactions.
+
+### Decision: Explicitly document basic synchronous failure semantics
+If any storage step fails, the export call should fail and return that error. The implementation will not add internal retries, compensation, or background recovery. Because the write path remains synchronous and non-transactional, partial persistence across tables or kinds remains possible and must be documented as an accepted trade-off for this stage of the project.
+
+Alternatives considered:
+- Add retries inside the request path: rejected because it introduces policy questions, duplicate-write risk, and longer tail latency without an idempotency story.
+- Add transactional coordination across tables: rejected because ClickHouse and the current storage model do not justify that complexity for this step.
+
+## Risks / Trade-offs
+
+- [A failed export may still leave some rows persisted] -> Accept and document this explicitly; add tests so future contributors understand the non-atomic behavior.
+- [Concurrency could make unit tests more timing-sensitive] -> Verify behavior through controlled fake stores and ordering signals rather than sleep-based assertions.
+- [The change could become a stepping stone to premature buffering features] -> Keep the scope limited to in-request concurrency and call out buffering, retries, and coalescing as non-goals.
+
+## Migration Plan
+
+1. Add the new ingestion capability spec that defines batching, per-kind sequencing, independent kind execution, and failure semantics.
+2. Update the export handler and any small supporting helpers needed to execute populated gauge and sum pipelines independently.
+3. Extend unit tests with fake-store coverage for mixed requests, per-kind ordering, skipped empty kinds, and failure propagation.
+4. Extend integration coverage only as needed to confirm the persisted rows remain correct under the updated execution model.
+
+## Open Questions
+
+- None for this scoped change. If higher sustained throughput becomes a measured problem later, that should be proposed separately with concrete requirements for buffering, retries, and idempotency.

--- a/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/proposal.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The current write path already does per-request batch inserts and deduplicates metadata within a request, which is a solid baseline, but it still processes gauge and sum persistence synchronously and leaves its throughput and failure semantics mostly implicit. This change is needed to improve ingestion throughput in a small, deliberate way without introducing premature complexity such as async buffering, retries, or cross-request write coalescing.
+
+## What Changes
+
+- Add an explicit normalized ingestion contract for gauge and sum exports that preserves request-scoped batching and allows independent metric kinds to be persisted concurrently within one export request.
+- Define the scoped write guarantees for the first throughput-focused implementation: metadata is written before datapoints within a kind, storage errors fail the export, and the service does not promise transactional atomicity, background retries, or idempotent replay handling.
+- Add focused tests for mixed gauge and sum export requests so the repository verifies the intended batching, per-kind sequencing, and non-goals of the write path.
+
+## Capabilities
+
+### New Capabilities
+- `normalized-metric-ingestion`: Covers request-scoped batching, per-kind persistence flow, and the bounded throughput guarantees for gauge and sum export ingestion.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: `metrics_service.go`, `clickhouse_client.go` only if small helper extraction is warranted, and relevant tests such as `server_test.go` and `integration_test.go`.
+- Affected systems: ClickHouse write behavior for normalized gauge and sum ingestion.
+- API impact: no OTLP/gRPC contract changes; the change affects how one export request is persisted internally.
+- Operational impact: throughput improves only within the existing synchronous request lifecycle; async buffering, retry/idempotency strategy, transactional guarantees, and cross-request write coalescing remain explicit non-goals.

--- a/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/specs/normalized-metric-ingestion/spec.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/specs/normalized-metric-ingestion/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Batch normalized writes per export request and metric kind
+The system SHALL derive normalized gauge and sum rows from one export request and SHALL persist each populated metric kind with request-scoped batch writes rather than issuing storage writes per datapoint.
+
+#### Scenario: One gauge export request writes one metadata batch and one datapoint batch
+- **WHEN** an export request contains one or more gauge datapoints and no sum datapoints
+- **THEN** the system MUST issue exactly one gauge metadata write and exactly one gauge datapoint write for that request
+
+#### Scenario: One sum export request writes one metadata batch and one datapoint batch
+- **WHEN** an export request contains one or more sum datapoints and no gauge datapoints
+- **THEN** the system MUST issue exactly one sum metadata write and exactly one sum datapoint write for that request
+
+#### Scenario: Empty kinds do not trigger storage writes
+- **WHEN** an export request produces no normalized rows for a metric kind
+- **THEN** the system MUST skip storage writes for that kind
+
+### Requirement: Process populated gauge and sum kinds independently within one export
+The system SHALL treat populated gauge and sum kinds as independent persistence pipelines within one export request. Neither kind SHALL be required to wait for the other kind to complete its storage work before starting its own pipeline.
+
+#### Scenario: Mixed export request starts both persistence pipelines independently
+- **WHEN** an export request contains both gauge datapoints and sum datapoints
+- **THEN** the system MUST be allowed to begin gauge persistence and sum persistence independently within the same export call
+
+#### Scenario: Per-kind ordering remains metadata before datapoints
+- **WHEN** the system persists one populated metric kind
+- **THEN** it MUST write that kind's metadata batch before writing that kind's datapoint batch
+
+### Requirement: Surface storage failures without retries or atomicity guarantees
+The system SHALL fail the export call when a storage step returns an error. The system SHALL NOT automatically retry failed storage writes, and it SHALL NOT claim all-or-nothing persistence across tables or metric kinds.
+
+#### Scenario: Metadata failure aborts that export call
+- **WHEN** a metadata write for a populated metric kind returns an error
+- **THEN** the export call MUST return an error for that request
+
+#### Scenario: Datapoint failure aborts that export call
+- **WHEN** a datapoint write for a populated metric kind returns an error after that kind's metadata write succeeded
+- **THEN** the export call MUST return an error for that request without retrying the failed write
+
+#### Scenario: Partial persistence remains possible across independent kinds
+- **WHEN** one metric kind finishes persisting successfully and another metric kind later fails during the same export request
+- **THEN** the export call MUST return an error and the already-persisted rows MAY remain stored

--- a/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/tasks.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-ingest-throughput/tasks.md
@@ -1,0 +1,16 @@
+## 1. Restructure the export write path
+
+- [x] 1.1 Update `metrics_service.go` to prepare normalized gauge and sum batches once per export request and skip storage work for empty kinds.
+- [x] 1.2 Introduce the smallest helper structure needed to run one metric kind as a metadata-then-datapoint persistence pipeline.
+- [x] 1.3 Execute populated gauge and sum pipelines independently within one export call while still returning a storage error when any pipeline fails.
+
+## 2. Verify batching, ordering, and failure behavior
+
+- [x] 2.1 Add unit-test fake store coverage for gauge-only and sum-only requests to verify one metadata batch and one datapoint batch per populated kind.
+- [x] 2.2 Add unit tests for mixed requests that verify empty kinds are skipped, metadata remains ordered before datapoints within a kind, and gauge and sum pipelines can start independently.
+- [x] 2.3 Add unit or integration coverage that verifies storage errors fail the export without retries and that partial persistence is treated as an accepted non-atomic outcome.
+
+## 3. Document and validate the scoped change
+
+- [x] 3.1 Update `README.md` to describe the synchronous request-scoped ingestion model, the per-kind concurrency improvement, and the explicit non-goals around buffering, retries, idempotency, and transactional guarantees.
+- [x] 3.2 Run `make test` and `make test-integration` to validate the updated write-path behavior.


### PR DESCRIPTION
This pull request improves the ingestion throughput of the OTLP metric store backend by allowing gauge and sum metric kinds to be persisted concurrently within a single export request, rather than serializing the two kinds. It introduces explicit requirements and documentation for the new ingestion behavior, updates the export handler implementation to use per-kind concurrency, and adds comprehensive tests to verify correct batching, ordering, and failure semantics. The changes are carefully scoped to avoid introducing background buffering, retries, or transactional guarantees.

**Implementation: Increased Throughput and Explicit Failure Semantics**
- The export handler in `metrics_service.go` now processes gauge and sum writes in parallel (when both are present) by running each kind’s metadata and datapoint writes as independent pipelines, while preserving the guarantee that metadata is written before datapoints for each kind. If any storage step fails, the export call fails immediately, but partial persistence across kinds is possible and explicitly documented. [[1]](diffhunk://#diff-6681b1be1bb86099cd6c02f991c8a34998d912323428739723a832d04ba345e4R28-R61) [[2]](diffhunk://#diff-6681b1be1bb86099cd6c02f991c8a34998d912323428739723a832d04ba345e4R6) [[3]](diffhunk://#diff-aca02f77801af77bed342da123e90d7eb57824312e486fc5d7635907881553d3R52-R61)

**Specification and Documentation:**
- Added new OpenSpec documentation (`.openspec.yaml`, `design.md`, `proposal.md`, and `spec.md`) that formalizes the requirements, goals, non-goals, and precise semantics for the new ingestion model. This includes explicit statements about batching, per-kind sequencing, independent execution, and failure behavior. [[1]](diffhunk://#diff-aff8f2aad85a08ee819055fa9fe04f174e45b7f862174a1b66fca4d77b9b0e7eR1-R2) [[2]](diffhunk://#diff-6e3b84d52d7c3af1935bdd51550cd4b377813e1330d1bc4bb219e9783d95c0bbR1-R61) [[3]](diffhunk://#diff-2651791badbd500165e5a2c31c186b17b00769468c7e5c03e756a111382b9d9aR1-R23) [[4]](diffhunk://#diff-5d853b56aae05fa346488c4beb2f042986ce097969c3a18b02feae756c303e0cR1-R42)

**Testing:**
- Introduced a comprehensive new unit test suite in `metrics_service_test.go` using a fake store, covering scenarios such as independent per-kind execution, batching behavior, correct ordering, skipping of empty kinds, error propagation, and partial persistence. These tests ensure the new concurrency and failure semantics are robust and verifiable.