### PR TITLE
[CHORE] add ingest observability instrumentation

### DIFF
--- a/otlp-metric-store-backend-go/README.md
+++ b/otlp-metric-store-backend-go/README.md
@@ -43,6 +43,34 @@ make test
 make test-integration
 ```
 
+## Observability
+
+The service keeps the existing stdout-based OpenTelemetry exporters for traces, metrics, and logs. This repository does not configure an external OTLP collector or backend.
+
+### Application metrics
+
+The service emits these application metrics in addition to the gRPC middleware telemetry:
+
+- `com.dash0.homeexercise.metrics.received`: count of OTLP export requests received
+- `com.dash0.homeexercise.metrics.exports`: count of completed export requests with a `com.dash0.outcome` attribute
+- `com.dash0.homeexercise.metrics.datapoints`: count of processed datapoints with a `com.dash0.metric.kind` attribute
+- `com.dash0.homeexercise.metrics.export.duration`: export request latency with a `com.dash0.outcome` attribute
+- `com.dash0.homeexercise.metrics.store.rows`: count of rows written to ClickHouse with `com.dash0.metric.kind` and `com.dash0.storage.operation` attributes
+- `com.dash0.homeexercise.metrics.store.failures`: count of ClickHouse write failures with `com.dash0.metric.kind` and `com.dash0.storage.operation` attributes
+- `com.dash0.homeexercise.metrics.store.duration`: ClickHouse write latency with `com.dash0.metric.kind`, `com.dash0.storage.operation`, and `com.dash0.outcome` attributes
+
+### Traces and logs
+
+- Export requests create an application span named `metrics.export`
+- ClickHouse writes create child spans named `clickhouse.<metric-kind>.<operation>`
+- Export request logs include aggregate metadata row and datapoint counts
+- ClickHouse failure logs identify the metric kind, storage operation, row count, and error
+- Startup logs make OpenTelemetry initialization, ClickHouse connection attempts, and listener failures explicit
+
+### Follow-up guidance
+
+Weaver adoption, observability by design, and CI-based observability contract testing are not implemented in this repository change. They are documented as recommended follow-up work once the service's emitted signals stabilize.
+
 ## Storage Model
 
 - `otel_metrics_gauge_metadata` and `otel_metrics_sum_metadata` store metric identity and descriptive metadata.

--- a/otlp-metric-store-backend-go/clickhouse_client.go
+++ b/otlp-metric-store-backend-go/clickhouse_client.go
@@ -65,111 +65,119 @@ func (s *ClickHouseMetricsStore) CreateTables(ctx context.Context) error {
 }
 
 func (s *ClickHouseMetricsStore) InsertGaugeMetadata(ctx context.Context, rows []MetricMetadataRow) error {
-	batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_gauge_metadata")
-	if err != nil {
-		return fmt.Errorf("preparing gauge metadata batch: %w", err)
-	}
-	for _, r := range rows {
-		if err := batch.Append(
-			r.MetadataKey,
-			replacementRankBigInt(r.ReplacementRank),
-			r.ResourceAttributes,
-			r.ResourceSchemaUrl,
-			r.ScopeName,
-			r.ScopeVersion,
-			r.ScopeAttributes,
-			r.ScopeDroppedAttrCount,
-			r.ScopeSchemaUrl,
-			r.ServiceName,
-			r.MetricName,
-			r.MetricDescription,
-			r.MetricUnit,
-			r.Attributes,
-		); err != nil {
-			return fmt.Errorf("appending gauge metadata row: %w", err)
+	return observeStoreOperation(ctx, "gauge", "metadata", len(rows), func(ctx context.Context) error {
+		batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_gauge_metadata")
+		if err != nil {
+			return fmt.Errorf("preparing gauge metadata batch: %w", err)
 		}
-	}
-	if err := batch.Send(); err != nil {
-		return fmt.Errorf("sending gauge metadata batch: %w", err)
-	}
-	return nil
+		for _, r := range rows {
+			if err := batch.Append(
+				r.MetadataKey,
+				replacementRankBigInt(r.ReplacementRank),
+				r.ResourceAttributes,
+				r.ResourceSchemaUrl,
+				r.ScopeName,
+				r.ScopeVersion,
+				r.ScopeAttributes,
+				r.ScopeDroppedAttrCount,
+				r.ScopeSchemaUrl,
+				r.ServiceName,
+				r.MetricName,
+				r.MetricDescription,
+				r.MetricUnit,
+				r.Attributes,
+			); err != nil {
+				return fmt.Errorf("appending gauge metadata row: %w", err)
+			}
+		}
+		if err := batch.Send(); err != nil {
+			return fmt.Errorf("sending gauge metadata batch: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *ClickHouseMetricsStore) InsertGaugeDataPoints(ctx context.Context, rows []GaugeDataPointRow) error {
-	batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_gauge")
-	if err != nil {
-		return fmt.Errorf("preparing gauge datapoint batch: %w", err)
-	}
-	for _, r := range rows {
-		if err := batch.Append(
-			r.MetadataKey,
-			r.StartTimeUnix,
-			r.TimeUnix,
-			r.Value,
-			r.Flags,
-		); err != nil {
-			return fmt.Errorf("appending gauge datapoint row: %w", err)
+	return observeStoreOperation(ctx, "gauge", "datapoints", len(rows), func(ctx context.Context) error {
+		batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_gauge")
+		if err != nil {
+			return fmt.Errorf("preparing gauge datapoint batch: %w", err)
 		}
-	}
-	if err := batch.Send(); err != nil {
-		return fmt.Errorf("sending gauge datapoint batch: %w", err)
-	}
-	return nil
+		for _, r := range rows {
+			if err := batch.Append(
+				r.MetadataKey,
+				r.StartTimeUnix,
+				r.TimeUnix,
+				r.Value,
+				r.Flags,
+			); err != nil {
+				return fmt.Errorf("appending gauge datapoint row: %w", err)
+			}
+		}
+		if err := batch.Send(); err != nil {
+			return fmt.Errorf("sending gauge datapoint batch: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *ClickHouseMetricsStore) InsertSumMetadata(ctx context.Context, rows []SumMetadataRow) error {
-	batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_sum_metadata")
-	if err != nil {
-		return fmt.Errorf("preparing sum metadata batch: %w", err)
-	}
-	for _, r := range rows {
-		if err := batch.Append(
-			r.MetadataKey,
-			replacementRankBigInt(r.ReplacementRank),
-			r.ResourceAttributes,
-			r.ResourceSchemaUrl,
-			r.ScopeName,
-			r.ScopeVersion,
-			r.ScopeAttributes,
-			r.ScopeDroppedAttrCount,
-			r.ScopeSchemaUrl,
-			r.ServiceName,
-			r.MetricName,
-			r.MetricDescription,
-			r.MetricUnit,
-			r.Attributes,
-			r.AggregationTemporality,
-			r.IsMonotonic,
-		); err != nil {
-			return fmt.Errorf("appending sum metadata row: %w", err)
+	return observeStoreOperation(ctx, "sum", "metadata", len(rows), func(ctx context.Context) error {
+		batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_sum_metadata")
+		if err != nil {
+			return fmt.Errorf("preparing sum metadata batch: %w", err)
 		}
-	}
-	if err := batch.Send(); err != nil {
-		return fmt.Errorf("sending sum metadata batch: %w", err)
-	}
-	return nil
+		for _, r := range rows {
+			if err := batch.Append(
+				r.MetadataKey,
+				replacementRankBigInt(r.ReplacementRank),
+				r.ResourceAttributes,
+				r.ResourceSchemaUrl,
+				r.ScopeName,
+				r.ScopeVersion,
+				r.ScopeAttributes,
+				r.ScopeDroppedAttrCount,
+				r.ScopeSchemaUrl,
+				r.ServiceName,
+				r.MetricName,
+				r.MetricDescription,
+				r.MetricUnit,
+				r.Attributes,
+				r.AggregationTemporality,
+				r.IsMonotonic,
+			); err != nil {
+				return fmt.Errorf("appending sum metadata row: %w", err)
+			}
+		}
+		if err := batch.Send(); err != nil {
+			return fmt.Errorf("sending sum metadata batch: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *ClickHouseMetricsStore) InsertSumDataPoints(ctx context.Context, rows []SumDataPointRow) error {
-	batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_sum")
-	if err != nil {
-		return fmt.Errorf("preparing sum datapoint batch: %w", err)
-	}
-	for _, r := range rows {
-		if err := batch.Append(
-			r.MetadataKey,
-			r.StartTimeUnix,
-			r.TimeUnix,
-			r.Value,
-			r.Flags,
-		); err != nil {
-			return fmt.Errorf("appending sum datapoint row: %w", err)
+	return observeStoreOperation(ctx, "sum", "datapoints", len(rows), func(ctx context.Context) error {
+		batch, err := s.conn.PrepareBatch(ctx, "INSERT INTO otel_metrics_sum")
+		if err != nil {
+			return fmt.Errorf("preparing sum datapoint batch: %w", err)
 		}
-	}
-	if err := batch.Send(); err != nil {
-		return fmt.Errorf("sending sum datapoint batch: %w", err)
-	}
-	return nil
+		for _, r := range rows {
+			if err := batch.Append(
+				r.MetadataKey,
+				r.StartTimeUnix,
+				r.TimeUnix,
+				r.Value,
+				r.Flags,
+			); err != nil {
+				return fmt.Errorf("appending sum datapoint row: %w", err)
+			}
+		}
+		if err := batch.Send(); err != nil {
+			return fmt.Errorf("sending sum datapoint batch: %w", err)
+		}
+		return nil
+	})
 }
 
 func (s *ClickHouseMetricsStore) Close() error {

--- a/otlp-metric-store-backend-go/metrics_service.go
+++ b/otlp-metric-store-backend-go/metrics_service.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 )
 
@@ -20,14 +24,50 @@ func newServer(addr string, store MetricsStore) colmetricspb.MetricsServiceServe
 }
 
 func (m *dash0MetricsServiceServer) Export(ctx context.Context, request *colmetricspb.ExportMetricsServiceRequest) (*colmetricspb.ExportMetricsServiceResponse, error) {
-	slog.DebugContext(ctx, "Received ExportMetricsServiceRequest")
+	start := time.Now()
+	resourceMetrics := request.GetResourceMetrics()
+	ctx, span := tracer.Start(ctx, "metrics.export", trace.WithAttributes(exportSpanAttributes(m.addr, len(resourceMetrics))...))
+	defer span.End()
+
+	slog.InfoContext(ctx, "Received ExportMetricsServiceRequest", slog.Int("com.dash0.resource_metrics_count", len(resourceMetrics)))
 	metricsReceivedCounter.Add(ctx, 1)
 
-	if m.store != nil {
-		rm := request.GetResourceMetrics()
-		gaugeRows := MapNormalizedGaugeRows(rm)
-		sumRows := MapNormalizedSumRows(rm)
+	gaugeRows := MapNormalizedGaugeRows(resourceMetrics)
+	sumRows := MapNormalizedSumRows(resourceMetrics)
+	totalMetadataRows := len(gaugeRows.Metadata) + len(sumRows.Metadata)
+	totalDataPoints := len(gaugeRows.DataPoints) + len(sumRows.DataPoints)
 
+	span.SetAttributes(
+		attribute.Int("com.dash0.export.metadata_rows", totalMetadataRows),
+		attribute.Int("com.dash0.export.datapoints", totalDataPoints),
+	)
+	span.AddEvent("mapping.completed", trace.WithAttributes(
+		attribute.Int("com.dash0.gauge.metadata_rows", len(gaugeRows.Metadata)),
+		attribute.Int("com.dash0.gauge.datapoints", len(gaugeRows.DataPoints)),
+		attribute.Int("com.dash0.sum.metadata_rows", len(sumRows.Metadata)),
+		attribute.Int("com.dash0.sum.datapoints", len(sumRows.DataPoints)),
+	))
+
+	slog.InfoContext(ctx,
+		"Mapped export request",
+		slog.Int("com.dash0.gauge_metadata_rows", len(gaugeRows.Metadata)),
+		slog.Int("com.dash0.gauge_datapoints", len(gaugeRows.DataPoints)),
+		slog.Int("com.dash0.sum_metadata_rows", len(sumRows.Metadata)),
+		slog.Int("com.dash0.sum_datapoints", len(sumRows.DataPoints)),
+	)
+
+	outcome := "success"
+	defer func() {
+		recordExportTelemetry(ctx, time.Since(start), outcome, len(gaugeRows.DataPoints), len(sumRows.DataPoints))
+		span.SetAttributes(outcomeAttr(outcome))
+		if outcome == "error" {
+			span.SetStatus(codes.Error, "export failed")
+		} else {
+			span.SetStatus(codes.Ok, "")
+		}
+	}()
+
+	if m.store != nil {
 		var wg sync.WaitGroup
 		errCh := make(chan error, 2)
 
@@ -59,10 +99,27 @@ func (m *dash0MetricsServiceServer) Export(ctx context.Context, request *colmetr
 
 		for err := range errCh {
 			if err != nil {
+				outcome = "error"
+				span.RecordError(err)
+				slog.ErrorContext(ctx,
+					"ExportMetricsServiceRequest failed",
+					slog.Int("com.dash0.gauge_metadata_rows", len(gaugeRows.Metadata)),
+					slog.Int("com.dash0.gauge_datapoints", len(gaugeRows.DataPoints)),
+					slog.Int("com.dash0.sum_metadata_rows", len(sumRows.Metadata)),
+					slog.Int("com.dash0.sum_datapoints", len(sumRows.DataPoints)),
+					slog.Any("com.dash0.error", err),
+				)
 				return nil, err
 			}
 		}
 	}
+
+	slog.InfoContext(ctx,
+		"ExportMetricsServiceRequest completed",
+		slog.String("com.dash0.outcome", outcome),
+		slog.Int("com.dash0.metadata_rows", totalMetadataRows),
+		slog.Int("com.dash0.datapoints", totalDataPoints),
+	)
 
 	return &colmetricspb.ExportMetricsServiceResponse{}, nil
 }

--- a/otlp-metric-store-backend-go/observability.go
+++ b/otlp-metric-store-backend-go/observability.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	metricKindKey           = attribute.Key("com.dash0.metric.kind")
+	storageOperationKey     = attribute.Key("com.dash0.storage.operation")
+	outcomeKey              = attribute.Key("com.dash0.outcome")
+	resourceMetricsCountKey = attribute.Key("com.dash0.resource_metrics.count")
+	dbBatchSizeKey          = attribute.Key("com.dash0.db.batch.size")
+)
+
+var (
+	tracer = otel.Tracer(name)
+
+	metricsReceivedCounter     metric.Int64Counter
+	exportsCompletedCounter    metric.Int64Counter
+	datapointsProcessedCounter metric.Int64Counter
+	exportDurationHistogram    metric.Float64Histogram
+	storageRowsCounter         metric.Int64Counter
+	storageFailuresCounter     metric.Int64Counter
+	storageDurationHistogram   metric.Float64Histogram
+)
+
+func init() {
+	var err error
+
+	metricsReceivedCounter, err = meter.Int64Counter(
+		"com.dash0.homeexercise.metrics.received",
+		metric.WithDescription("The number of OTLP export requests received by otlp-metrics-processor-backend"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	exportsCompletedCounter, err = meter.Int64Counter(
+		"com.dash0.homeexercise.metrics.exports",
+		metric.WithDescription("The number of OTLP export requests completed by otlp-metrics-processor-backend"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	datapointsProcessedCounter, err = meter.Int64Counter(
+		"com.dash0.homeexercise.metrics.datapoints",
+		metric.WithDescription("The number of OTLP datapoints processed by otlp-metrics-processor-backend"),
+		metric.WithUnit("{datapoint}"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	exportDurationHistogram, err = meter.Float64Histogram(
+		"com.dash0.homeexercise.metrics.export.duration",
+		metric.WithDescription("The time spent processing an OTLP export request"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	storageRowsCounter, err = meter.Int64Counter(
+		"com.dash0.homeexercise.metrics.store.rows",
+		metric.WithDescription("The number of rows written to ClickHouse by otlp-metrics-processor-backend"),
+		metric.WithUnit("{row}"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	storageFailuresCounter, err = meter.Int64Counter(
+		"com.dash0.homeexercise.metrics.store.failures",
+		metric.WithDescription("The number of ClickHouse write failures in otlp-metrics-processor-backend"),
+		metric.WithUnit("{operation}"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	storageDurationHistogram, err = meter.Float64Histogram(
+		"com.dash0.homeexercise.metrics.store.duration",
+		metric.WithDescription("The time spent writing ClickHouse batches in otlp-metrics-processor-backend"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func metricKindAttr(kind string) attribute.KeyValue {
+	return metricKindKey.String(kind)
+}
+
+func storageOperationAttr(operation string) attribute.KeyValue {
+	return storageOperationKey.String(operation)
+}
+
+func outcomeAttr(outcome string) attribute.KeyValue {
+	return outcomeKey.String(outcome)
+}
+
+func exportSpanAttributes(addr string, resourceMetricsCount int) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		resourceMetricsCountKey.Int(resourceMetricsCount),
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return append(attrs, semconv.ServerAddressKey.String(addr))
+	}
+
+	attrs = append(attrs, semconv.ServerAddressKey.String(host))
+	if parsedPort, err := strconv.Atoi(port); err == nil {
+		attrs = append(attrs, semconv.ServerPortKey.Int(parsedPort))
+	}
+
+	return attrs
+}
+
+func recordExportTelemetry(ctx context.Context, duration time.Duration, outcome string, gaugeDataPoints int, sumDataPoints int) {
+	attrs := metric.WithAttributes(outcomeAttr(outcome))
+	exportsCompletedCounter.Add(ctx, 1, attrs)
+	exportDurationHistogram.Record(ctx, duration.Seconds(), attrs)
+
+	if gaugeDataPoints > 0 {
+		datapointsProcessedCounter.Add(ctx, int64(gaugeDataPoints), metric.WithAttributes(metricKindAttr("gauge")))
+	}
+	if sumDataPoints > 0 {
+		datapointsProcessedCounter.Add(ctx, int64(sumDataPoints), metric.WithAttributes(metricKindAttr("sum")))
+	}
+}
+
+func observeStoreOperation(ctx context.Context, metricKind string, operation string, rowCount int, run func(context.Context) error) error {
+	ctx, span := tracer.Start(ctx,
+		"clickhouse."+metricKind+"."+operation,
+		trace.WithAttributes(
+			metricKindAttr(metricKind),
+			storageOperationAttr(operation),
+			dbBatchSizeKey.Int(rowCount),
+		),
+	)
+	defer span.End()
+
+	start := time.Now()
+	err := run(ctx)
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		storageFailuresCounter.Add(ctx, 1, metric.WithAttributes(metricKindAttr(metricKind), storageOperationAttr(operation)))
+		slog.ErrorContext(ctx,
+			"ClickHouse write failed",
+			slog.String("com.dash0.metric.kind", metricKind),
+			slog.String("com.dash0.storage.operation", operation),
+			slog.Int("com.dash0.row_count", rowCount),
+			slog.Any("com.dash0.error", err),
+		)
+	} else {
+		storageRowsCounter.Add(ctx, int64(rowCount), metric.WithAttributes(metricKindAttr(metricKind), storageOperationAttr(operation)))
+		span.SetStatus(codes.Ok, "")
+	}
+
+	storageDurationHistogram.Record(
+		ctx,
+		time.Since(start).Seconds(),
+		metric.WithAttributes(metricKindAttr(metricKind), storageOperationAttr(operation), outcomeAttr(outcome)),
+	)
+
+	return err
+}

--- a/otlp-metric-store-backend-go/openspec/changes/improve-observability/.openspec.yaml
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/otlp-metric-store-backend-go/openspec/changes/improve-observability/design.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-observability/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The service currently exposes only minimal observability. gRPC server spans are enabled through `otelgrpc`, but application telemetry is limited to a single request counter and sparse debug logs. The OpenTelemetry SDK is configured with stdout exporters only, and this change keeps that model in place.
+
+This change crosses startup, request handling, storage integration, tests, and documentation. It also touches OpenTelemetry resource configuration and semantic conventions, so decisions made here need to be consistent across the service.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Instrument the ingest path with actionable metrics, spans, and structured logs for request volume, datapoint volume, latency, and failures.
+- Align resource attributes and emitted telemetry fields with the latest stable OpenTelemetry semantic conventions supported by the Go dependencies in the repository.
+- Document the observability contract exposed by the service and explicitly capture follow-up adoption guidance for Weaver and CI-based contract testing.
+
+**Non-Goals:**
+- Redesign the ingest pipeline around asynchronous queues, retries, or background workers.
+- Introduce a metrics query API, dashboards, or alert rules in this repository.
+- Add observability support for histogram, exponential histogram, or summary ingestion beyond the existing gauge and sum scope.
+- Change the service from stdout-based telemetry export to an external collector or backend integration.
+
+## Decisions
+
+### Keep stdout exporters and improve the emitted signals
+The service will keep the current stdout exporters for traces, metrics, and logs. The change will focus on improving what the service emits through those pipelines rather than adding exporter configurability.
+
+Rationale:
+- Exporter changes are out of scope for this iteration.
+- Keeping stdout mode avoids startup and configuration complexity while still allowing instrumentation work to proceed.
+
+Alternatives considered:
+- Add configurable OTLP exporters: rejected for this change because the requested scope is to retain today's stdout-only behavior.
+- Add a vendor-specific exporter directly: rejected because exporter integration is out of scope.
+
+### Instrument the request pipeline at application boundaries instead of every helper
+Instrumentation will focus on stable boundaries: request receipt, mapping completion, metadata insert, datapoint insert, and request completion. The service will emit counters and histograms with low-cardinality attributes such as metric kind, outcome, and storage step.
+
+Rationale:
+- Boundary instrumentation captures throughput and latency with limited cardinality risk.
+- It avoids scattering telemetry across mapper internals that are likely to change.
+- The repository does not have an established external dashboard contract, so consistency with the existing application metric naming is the safest baseline.
+
+Alternatives considered:
+- Instrument every mapping helper: rejected because it adds noise and maintenance cost.
+- Rely on gRPC middleware spans only: rejected because middleware does not expose domain-specific row counts or storage steps.
+
+### Standardize on the latest stable semantic convention version supported by the repo
+The implementation will update OpenTelemetry dependencies as needed and use the latest stable semantic convention package supported by those versions for resource attributes and span/log field naming.
+
+Rationale:
+- This keeps telemetry interoperable with current tooling and avoids drifting field names.
+- The repository already hard-codes a semantic convention version, so making the upgrade explicit reduces ambiguity.
+
+Alternatives considered:
+- Leave the current version in place: rejected because the requested change explicitly requires latest-version alignment.
+- Invent custom attribute names for new telemetry: rejected except where no stable semantic convention exists.
+
+### Document the observability contract and recommend stronger governance follow-up
+This change will document the emitted signals in the repository. It will also capture that Weaver and observability-by-design contract testing in CI are follow-up considerations only and are not being implemented in this change.
+
+Rationale:
+- The immediate gap is lack of clear signal documentation and an explicit observability contract.
+- Weaver and contract-testing adoption is valuable, but it is a broader process and tooling decision than this change needs to implement.
+
+Alternatives considered:
+- Implement contract-testing and Weaver adoption now: rejected because it expands scope beyond the current instrumentation and readiness work.
+
+## Risks / Trade-offs
+
+- Higher telemetry volume from per-request instrumentation -> Mitigation: keep attributes low-cardinality and emit aggregate metrics instead of per-series dimensions.
+- Semantic convention upgrades may require dependency and field-name changes -> Mitigation: scope the upgrade to the service resource and newly added telemetry, and validate build/test compatibility.
+- Logs, traces, and metrics may duplicate some information -> Mitigation: define clear ownership for each signal type and avoid high-volume debug logs in steady state.
+- Documentation without automated contract enforcement may drift over time -> Mitigation: document recommended follow-up adoption of Weaver and CI contract testing.
+
+## Migration Plan
+
+1. Update the OTel bootstrap path for semantic convention alignment while preserving stdout exporters.
+2. Add ingest and storage instrumentation while preserving the existing synchronous request behavior.
+3. Update README with signal names and follow-up recommendations for Weaver and CI contract testing.
+4. Roll back by removing the new instrumentation if issues appear during rollout.
+
+## Open Questions
+
+- None for this change.

--- a/otlp-metric-store-backend-go/openspec/changes/improve-observability/proposal.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-observability/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The service has basic OpenTelemetry wiring, but it does not yet provide sufficient observability for the ingest path. We need actionable metrics, traces, logs, and health signals now so operators can understand throughput, failures, storage latency, and service readiness while keeping the current stdout-based export model.
+
+## What Changes
+
+- Add first-class observability for OTLP metric ingestion, including request, mapping, and ClickHouse write telemetry.
+- Adopt the latest stable OpenTelemetry semantic conventions used by the Go SDK and apply them consistently to service resource attributes, spans, and log fields.
+- Document the emitted observability signals and capture follow-up guidance to evaluate Weaver and observability-by-design contract testing in CI.
+
+## Capabilities
+
+### New Capabilities
+- `ingest-observability`: Improved telemetry coverage for metric ingestion, including structured logs, traces, metrics, and semantic convention alignment.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected code: `server.go`, `otel.go`, `metrics_service.go`, `clickhouse_client.go`, tests, and README/run instructions.
+- Affected systems: OpenTelemetry SDK configuration and operational dashboards/alerts built on emitted signals.
+- Dependencies: OpenTelemetry Go SDK/exporter packages may need updates to align with the latest stable semantic convention version.

--- a/otlp-metric-store-backend-go/openspec/changes/improve-observability/specs/ingest-observability/spec.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-observability/specs/ingest-observability/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Stdout telemetry export remains the service default
+The service SHALL keep stdout-based OpenTelemetry export for traces, metrics, and logs while observability improvements are added to the emitted signals.
+
+#### Scenario: Service starts normally
+- **WHEN** the service initializes its OpenTelemetry SDK pipelines
+- **THEN** it configures stdout exporters for traces, metrics, and logs as it does today
+
+#### Scenario: Observability work is added
+- **WHEN** new metrics, logs, and trace annotations are introduced by this change
+- **THEN** they are emitted through the existing stdout-based telemetry pipeline without requiring external collector configuration
+
+### Requirement: Ingest pipeline metrics
+The service SHALL emit application metrics for OTLP export requests and storage work that let operators observe request rate, datapoint volume, latency, and failures for gauge and sum ingestion.
+
+#### Scenario: Successful request emits throughput metrics
+- **WHEN** an OTLP export request containing gauge and or sum datapoints is processed successfully
+- **THEN** the service records request and datapoint metrics that distinguish the processed metric kinds and successful outcome
+
+#### Scenario: Failed storage work emits failure metrics
+- **WHEN** metadata or datapoint insertion fails for a metric kind
+- **THEN** the service records failure metrics that identify the failed pipeline step and the affected metric kind
+
+### Requirement: Ingest pipeline tracing and logging
+The service SHALL emit structured logs and application trace annotations for mapping and ClickHouse write stages with low-cardinality operational context.
+
+#### Scenario: Request completes successfully
+- **WHEN** the service finishes processing an OTLP export request
+- **THEN** it emits logs and trace attributes or events that include request outcome and aggregate row counts without embedding high-cardinality datapoint attributes
+
+#### Scenario: Request fails during storage
+- **WHEN** the service returns an error because a storage operation fails
+- **THEN** it emits an error log and trace failure details that identify the failing stage and metric kind
+
+### Requirement: Semantic convention alignment
+The service SHALL use the latest stable OpenTelemetry semantic conventions supported by its Go dependencies for resource attributes and newly added telemetry fields.
+
+#### Scenario: Service resource is initialized
+- **WHEN** OpenTelemetry SDK resources are created during startup
+- **THEN** the service uses the latest stable semantic convention package selected for the repository to populate standard service attributes
+
+#### Scenario: New telemetry fields are added
+- **WHEN** spans, logs, or metrics need standard attribute names covered by OpenTelemetry semantic conventions
+- **THEN** the implementation uses the selected stable semantic convention names instead of ad hoc alternatives
+
+### Requirement: Observability behavior is documented and tested
+The service SHALL document its observability behavior, including the signals it emits, and it SHALL identify Weaver and CI-based observability contract testing as recommended follow-up adoption work.
+
+#### Scenario: Operators review repository documentation
+- **WHEN** an operator reads the project documentation
+- **THEN** they can identify which signals are emitted and that stdout export remains in use
+
+#### Scenario: Team reviews observability guidance
+- **WHEN** engineers review the observability documentation for this service
+- **THEN** they can identify Weaver and CI-based contract testing as recommended next steps for stronger observability governance

--- a/otlp-metric-store-backend-go/openspec/changes/improve-observability/tasks.md
+++ b/otlp-metric-store-backend-go/openspec/changes/improve-observability/tasks.md
@@ -1,0 +1,21 @@
+## 1. OpenTelemetry setup
+
+- [x] 1.1 Update OpenTelemetry dependencies and semantic convention imports to the latest stable version supported by the repository.
+- [x] 1.2 Keep stdout exporters in `otel.go` while aligning the bootstrap code and emitted metadata with the selected semantic conventions.
+- [x] 1.3 Update service resource initialization to use the selected semantic conventions consistently for standard service attributes.
+
+## 2. Ingest instrumentation
+
+- [x] 2.1 Add application metrics for export request counts, datapoint counts, ingest latency, and failure outcomes with low-cardinality attributes.
+- [x] 2.2 Instrument the export flow in `metrics_service.go` with request-stage spans, structured logs, and aggregate row-count context.
+- [x] 2.3 Instrument ClickHouse metadata and datapoint insert paths with latency and failure telemetry for gauge and sum pipelines.
+
+## 3. Health and readiness
+
+- [x] 3.1 Review startup and failure-path logs to ensure storage initialization problems are clearly observable without adding a readiness endpoint.
+
+## 4. Validation and documentation
+
+- [x] 4.1 Update `README.md` with emitted operational signals and stdout telemetry behavior.
+- [x] 4.2 Document recommended follow-up adoption of Weaver and CI-based observability contract testing.
+- [x] 4.3 Run `make lint` and any targeted checks needed after the observability changes.

--- a/otlp-metric-store-backend-go/otel.go
+++ b/otlp-metric-store-backend-go/otel.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
@@ -15,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 )
 
 var res = resource.NewWithAttributes(
@@ -23,6 +24,7 @@ var res = resource.NewWithAttributes(
 	semconv.ServiceNameKey.String("otlp-metrics-processor-backend"),
 	semconv.ServiceNamespaceKey.String("dash0-exercise"),
 	semconv.ServiceVersionKey.String("1.0.0"),
+	semconv.ServiceInstanceIDKey.String(uuid.NewString()),
 )
 
 // setupOTelSDK bootstraps the OpenTelemetry pipeline.

--- a/otlp-metric-store-backend-go/server.go
+++ b/otlp-metric-store-backend-go/server.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -29,20 +28,9 @@ var (
 const name = "dash0.com/otlp-log-processor-backend"
 
 var (
-	meter                  = otel.Meter(name)
-	logger                 = otelslog.NewLogger(name)
-	metricsReceivedCounter metric.Int64Counter
+	meter  = otel.Meter(name)
+	logger = otelslog.NewLogger(name)
 )
-
-func init() {
-	var err error
-	metricsReceivedCounter, err = meter.Int64Counter("com.dash0.homeexercise.metrics.received",
-		metric.WithDescription("The number of metrics received by otlp-metrics-processor-backend"),
-		metric.WithUnit("{metric}"))
-	if err != nil {
-		panic(err)
-	}
-}
 
 func main() {
 	if err := run(); err != nil {
@@ -57,6 +45,7 @@ func run() (err error) {
 	// Set up OpenTelemetry.
 	otelShutdown, err := setupOTelSDK(context.Background())
 	if err != nil {
+		slog.Error("Failed to initialize OpenTelemetry SDK", slog.Any("com.dash0.error", err))
 		return
 	}
 
@@ -66,20 +55,30 @@ func run() (err error) {
 	}()
 
 	flag.Parse()
+	slog.Info("Configuration loaded",
+		slog.String("com.dash0.listen_addr", *listenAddr),
+		slog.Int("com.dash0.max_receive_message_size", *maxReceiveMessageSize),
+		slog.String("com.dash0.clickhouse_addr", *clickhouseAddr),
+	)
 
 	store, err := setupMetricsStore(context.Background())
 	if err != nil {
+		slog.Error("Failed to initialize metrics store", slog.Any("com.dash0.error", err))
 		return err
 	}
 	if store != nil {
+		slog.Info("Metrics store initialized", slog.String("com.dash0.clickhouse_addr", *clickhouseAddr), slog.String("com.dash0.clickhouse_database", *clickhouseDatabase))
 		defer func() {
 			err = errors.Join(err, store.Close())
 		}()
+	} else {
+		slog.Info("Metrics store disabled")
 	}
 
-	slog.Debug("Starting listener", slog.String("listenAddr", *listenAddr))
+	slog.Debug("Starting listener", slog.String("com.dash0.listen_addr", *listenAddr))
 	listener, err := net.Listen("tcp", *listenAddr)
 	if err != nil {
+		slog.Error("Failed to start listener", slog.String("com.dash0.listen_addr", *listenAddr), slog.Any("com.dash0.error", err))
 		return err
 	}
 
@@ -100,6 +99,7 @@ func setupMetricsStore(ctx context.Context) (MetricsStore, error) {
 		return nil, nil
 	}
 
+	slog.Info("Connecting to ClickHouse", slog.String("com.dash0.clickhouse_addr", *clickhouseAddr), slog.String("com.dash0.clickhouse_database", *clickhouseDatabase))
 	store, err := NewClickHouseMetricsStore(ctx, *clickhouseAddr, *clickhouseDatabase, *clickhouseUsername, *clickhousePassword)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request significantly improves observability for the OTLP metric ingestion service. It adds comprehensive OpenTelemetry-based metrics, traces, and structured logs for both the ingest and storage paths, aligns field names and resource attributes with the latest stable semantic conventions, and documents the observability contract and follow-up recommendations. The changes do not alter the stdout-based exporter model but provide much richer and actionable telemetry for operators.

**Observability instrumentation:**

* Introduced a new `observability.go` module that defines and records application metrics, traces, and logs for OTLP export requests and ClickHouse storage operations, including request counts, datapoint counts, latencies, and failure tracking, all using standardized semantic conventions.
* The ingest pipeline (`metrics_service.go`) now emits detailed spans, logs, and metrics for each export request, including mapping, storage, and error handling, and uses low-cardinality attributes for robust telemetry. [[1]](diffhunk://#diff-6681b1be1bb86099cd6c02f991c8a34998d912323428739723a832d04ba345e4R7-R11) [[2]](diffhunk://#diff-6681b1be1bb86099cd6c02f991c8a34998d912323428739723a832d04ba345e4L23-R70) [[3]](diffhunk://#diff-6681b1be1bb86099cd6c02f991c8a34998d912323428739723a832d04ba345e4R102-R123)

**Storage instrumentation:**

* All ClickHouse insert operations in `clickhouse_client.go` are now wrapped in the new `observeStoreOperation` function, which emits spans, metrics, and logs for each batch write, capturing operation type, metric kind, row counts, and errors. [[1]](diffhunk://#diff-63ee0c7f57d11bee9e09d013c54f0cc60a6d410daf22944c09dd3a82b793b391R68) [[2]](diffhunk://#diff-63ee0c7f57d11bee9e09d013c54f0cc60a6d410daf22944c09dd3a82b793b391R97-R101) [[3]](diffhunk://#diff-63ee0c7f57d11bee9e09d013c54f0cc60a6d410daf22944c09dd3a82b793b391R121-R125) [[4]](diffhunk://#diff-63ee0c7f57d11bee9e09d013c54f0cc60a6d410daf22944c09dd3a82b793b391R156-R160) [[5]](diffhunk://#diff-63ee0c7f57d11bee9e09d013c54f0cc60a6d410daf22944c09dd3a82b793b391R180)

**Documentation and specification:**

* The `README.md` now documents all emitted observability signals (metrics, traces, logs), their attributes, and provides guidance for future adoption of Weaver and contract testing.
* Added OpenSpec design and proposal documents detailing the motivation, goals, decisions, risks, and migration plan for the observability improvements. [[1]](diffhunk://#diff-ab3e990b10474d2b20ce8f489f9680ee6eca76fcfec910dc6a87ede9ab1fd0e7R1-R82) [[2]](diffhunk://#diff-572cd8fb62a3c4750097c9be3d1a3425c5bfae7793972123fc45b03031a603d0R1-R22) [[3]](diffhunk://#diff-4cf53fb060f17d81730d1b1fc604f1c9974fa3afe3ada0b7060a65e8552e1078R1-R2)